### PR TITLE
Prevent autofill on EditForm by adding ignore attributes

### DIFF
--- a/Web.Client/Pages/ScraperTasks/ScraperTaskEditPage.razor
+++ b/Web.Client/Pages/ScraperTasks/ScraperTaskEditPage.razor
@@ -10,7 +10,7 @@
 }
 else
 {
-    <EditForm Model="model" OnValidSubmit="HandleValidSubmit">
+    <EditForm Model="model" OnValidSubmit="HandleValidSubmit" autocomplete="off" data-1p-ignore data-lpignore="true">
         <DataAnnotationsValidator />
 
         <div class="row">


### PR DESCRIPTION
Added autocomplete="off", data-1p-ignore, and data-lpignore="true" to the EditForm to prevent browsers and password managers from autofilling or interfering with form fields.