### PR TITLE
Update package versions and refactor mailing service

### DIFF
--- a/Application/ApplicationServiceRegistration.cs
+++ b/Application/ApplicationServiceRegistration.cs
@@ -21,18 +21,6 @@ public static class DependencyInjection
 	public static IServiceCollection AddApplicationServices(this IServiceCollection services, IConfiguration configuration)
 	{
 		RegisterMessaging(services);
-		//// Registrace MediatR
-		//services.AddMediatR(cfg =>
-		//{
-		//	cfg.RegisterServicesFromAssembly(typeof(DependencyInjection).Assembly);
-
-		//	// Registrace chování
-		//	cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
-		//	cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
-		//});
-
-		//// Registrace AutoMapperu
-		//services.AddAutoMapper(typeof(DependencyInjection).Assembly);
 
 		//// Registrace validátorů
 		//services.AddValidatorsFromAssembly(typeof(DependencyInjection).Assembly);

--- a/Application/Features/Scraping/ListingNotificationService.cs
+++ b/Application/Features/Scraping/ListingNotificationService.cs
@@ -21,7 +21,7 @@ public class ListingNotificationService : IListingNotificationService
 	{
 		if (report.NewListingsCount > 0 || report.PriceChangedListingsCount > 0)
 		{
-			await mailerService.SendNewListingsAsync(report, recipients, cancellationToken);
+			await mailerService.SendListingReportAsync(report, recipients, cancellationToken);
 			logger.LogInformation("Notifikace odeslána.");
 		}
 		else

--- a/Application/Interfaces/Mailing/IMailerService.cs
+++ b/Application/Interfaces/Mailing/IMailerService.cs
@@ -4,5 +4,5 @@ namespace RealityScraper.Application.Interfaces.Mailing;
 
 public interface IMailerService
 {
-	Task SendNewListingsAsync(ScrapingReport scrapingReport, List<string> recipients, CancellationToken cancellationToken);
+	Task SendListingReportAsync(ScrapingReport scrapingReport, List<string> recipients, CancellationToken cancellationToken);
 }

--- a/Application/Services/Mailing/MailerService.cs
+++ b/Application/Services/Mailing/MailerService.cs
@@ -5,27 +5,22 @@ namespace RealityScraper.Application.Services.Mailing;
 
 public class MailerService : IMailerService
 {
-	private readonly IEmailGenerator htmlMailBodyGenerator;
+	private readonly IEmailGenerator emailGenerator;
 	private readonly IEmailService emailService;
 
-	public MailerService(IEmailGenerator htmlMailBodyGenerator, IEmailService emailService)
+	public MailerService(IEmailGenerator emailGenerator, IEmailService emailService)
 	{
-		this.htmlMailBodyGenerator = htmlMailBodyGenerator;
+		this.emailGenerator = emailGenerator;
 		this.emailService = emailService;
 	}
 
-	//public async Task SendEmailAsync(string to, string subject, string body)
-	//{
-	//	throw new NotImplementedException();
-	//}
-
-	public async Task SendNewListingsAsync(ScrapingReport scrapingReport, List<string> recipients, CancellationToken cancellationToken)
+	public async Task SendListingReportAsync(ScrapingReport scrapingReport, List<string> recipients, CancellationToken cancellationToken)
 	{
 		var date = scrapingReport.ReportDate.ToString("dd.MM.yyyy");
 		var subject = string.IsNullOrWhiteSpace(scrapingReport.TaskName)
 			? $"Nové realitní nabídky ({date})"
 			: $"{scrapingReport.TaskName} – nové nabídky ({date})";
-		var emailBody = await htmlMailBodyGenerator.GenerateHtmlBodyAsync(scrapingReport, cancellationToken);
+		var emailBody = await emailGenerator.GenerateHtmlBodyAsync(scrapingReport, cancellationToken);
 		await emailService.SendEmailNotificationAsync(subject, emailBody, recipients, cancellationToken);
 	}
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,37 +5,37 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Blazilla" Version="2.3.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-    <PackageVersion Include="Cronos" Version="0.11.1" />
-    <PackageVersion Include="FluentAssertions" Version="8.8.0" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="Cronos" Version="0.12.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="FluentAssertions.Analyzers" Version="0.34.1" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageVersion Include="Havit.Blazor.Components.Web.Bootstrap" Version="4.23.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageVersion Include="Havit.Blazor.Components.Web.Bootstrap" Version="4.24.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="RazorEngineCore" Version="2026.1.1" />
-    <PackageVersion Include="Resend" Version="0.2.2" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.13.8" />
+    <PackageVersion Include="Resend" Version="0.4.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.0" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="Selenium.Support" Version="4.41.0" />
     <PackageVersion Include="Selenium.WebDriver" Version="4.41.0" />


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the mailing service and its interface, as well as updates to package dependencies. The most significant changes include renaming and generalizing the mailing service method for sending listing reports, updating injected dependencies for clarity, and upgrading various NuGet packages for improved stability and features.

### Mailing Service Refactor

* Renamed the mailing method from `SendNewListingsAsync` to `SendListingReportAsync` in both the `IMailerService` interface and its implementation, making the method name more general and reflective of its purpose. (`Application/Interfaces/Mailing/IMailerService.cs`, `Application/Services/Mailing/MailerService.cs`) [[1]](diffhunk://#diff-19cf51e69350c5bdc51769d97ea3a4e9c4a37d4c761d74ad6773d33e86201081L7-R7) [[2]](diffhunk://#diff-0a6b863bf6d8f08032b9fccb4d6fa0fd26295a23e749ee3baf466a0214c1e345L8-R23)
* Updated the usage of the mailing method in `ListingNotificationService` to call the new `SendListingReportAsync` method. (`Application/Features/Scraping/ListingNotificationService.cs`)
* Renamed the injected dependency in `MailerService` from `htmlMailBodyGenerator` to `emailGenerator` for improved clarity and consistency. (`Application/Services/Mailing/MailerService.cs`)

### Dependency and Package Updates

* Upgraded several NuGet package versions in `Directory.Packages.props`, including `coverlet.collector`, `Cronos`, `FluentAssertions`, `Havit.Blazor.Components.Web.Bootstrap`, various `Microsoft.*` packages, `Resend`, and `Scalar.AspNetCore`, to ensure the project uses the latest stable releases. (`Directory.Packages.props`)

### Code Cleanup

* Removed commented-out registration code for MediatR and AutoMapper in the dependency injection setup, reducing clutter and improving maintainability. (`Application/ApplicationServiceRegistration.cs`)