### PR TITLE
CI: multi-stage Docker build, image promotion & Release pipeline

### DIFF
--- a/.github/workflows/assign-pr-author.yml
+++ b/.github/workflows/assign-pr-author.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Assign PR author when no assignee exists
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-﻿# This workflow will build a .NET project
+# This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET Build
@@ -8,11 +8,16 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v5
@@ -23,6 +28,13 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore -c Release
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build -c Release --verbosity normal --logger "trx" --results-directory ./TestResults
+    - name: Upload test results
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: ./TestResults/**/*.trx
+        if-no-files-found: ignore

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,40 @@
+name: Promote image to stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: 'Source tag to promote (e.g. test or sha-1a2b3c4)'
+        required: true
+        default: 'test'
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Configure required reviewers in Settings -> Environments to gate prod promotion.
+    environment: production
+
+    steps:
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Retag ${{ inputs.source }} -> stable (no rebuild)
+      run: |
+        IMAGE=ghcr.io/${{ github.repository }}
+        docker buildx imagetools create --tag "$IMAGE:stable" "$IMAGE:${{ inputs.source }}"
+
+    - name: Show promoted digest
+      run: docker buildx imagetools inspect ghcr.io/${{ github.repository }}:stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,16 @@
-name: .NET Build and Docker Push
+name: Build and push image (test)
 
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Docker image tag'
-        required: false
-        default: 'latest'
-        type: string
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v5
@@ -24,32 +23,36 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Build
-      run: dotnet build --no-restore -c Release
-
     - name: Test
-      run: dotnet test --no-build --verbosity normal -c Release
+      run: dotnet test -c Release --no-restore --verbosity normal
 
-    - name: Publish
-      run: dotnet publish Web.Api/Web.Api.csproj -c Release -o ./publish --no-build --no-restore
-
-    - name: Login to GitHub Container Registry
+    - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build Docker image
-      run: |
-        docker build -t ghcr.io/${{ github.repository }}:${{ inputs.tag }} -f ./Dockerfile .
-        if [ "${{ inputs.tag }}" != "latest" ]; then
-          docker tag ghcr.io/${{ github.repository }}:${{ inputs.tag }} ghcr.io/${{ github.repository }}:latest
-        fi
+    - name: Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+        # Every build goes to the test environment, plus an immutable per-commit tag.
+        tags: |
+          type=raw,value=test
+          type=sha,prefix=sha-,format=short
 
-    - name: Push Docker image
-      run: |
-        docker push ghcr.io/${{ github.repository }}:${{ inputs.tag }}
-        if [ "${{ inputs.tag }}" != "latest" ]; then
-          docker push ghcr.io/${{ github.repository }}:latest
-        fi
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,47 @@
-FROM mcr.microsoft.com/dotnet/aspnet:10.0
+# syntax=docker/dockerfile:1
+
+# --- Build stage: restore + publish from source ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy central build/package configuration first so the restore layer is cached
+# until one of these (or a .csproj below) actually changes.
+COPY global.json Directory.Build.props Directory.Packages.props ./
+
+# Copy every project file in Web.Api's graph so restore resolves the full set.
+COPY Application/Application.csproj Application/
+COPY Domain/Domain.csproj Domain/
+COPY SharedKernel/SharedKernel.csproj SharedKernel/
+COPY Infrastructure/Infrastructure.csproj Infrastructure/
+COPY Web.Api/Web.Api.csproj Web.Api/
+COPY Web.Client/Web.Client.csproj Web.Client/
+COPY Web.Shared/Web.Shared.csproj Web.Shared/
+
+RUN dotnet restore Web.Api/Web.Api.csproj
+
+# Copy the rest of the sources and publish (also builds the Blazor WASM client).
+COPY . .
+RUN dotnet publish Web.Api/Web.Api.csproj -c Release -o /app/publish --no-restore /p:UseAppHost=false
+
+# --- Runtime stage ---
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 EXPOSE 5000
 
+# The image already ships a non-root user "app" (UID 1654 / $APP_UID); just install
+# curl for the healthcheck and hand the writable files volume to that user.
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r appuser && useradd -r -g appuser appuser \
-    && mkdir -p /app/files && chown -R appuser:appuser /app/files
+    && mkdir -p /app/files && chown -R $APP_UID:$APP_UID /app/files
 
 ENV ASPNETCORE_URLS=http://+:5000
 ENV ASPNETCORE_ENVIRONMENT=Production
 
-COPY ./publish .
+COPY --from=build /app/publish .
 
 VOLUME ["/app/files"]
 
-USER appuser
+USER $APP_UID
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:5000/health || exit 1

--- a/README.md
+++ b/README.md
@@ -143,13 +143,18 @@ docker run -p 5000:5000 \
   reality-scraper
 ```
 
-Docker image je dostupný i z GitHub Container Registry:
+Docker image je dostupný z GitHub Container Registry ve dvou pohyblivých tazích podle prostředí:
 
 ```
-ghcr.io/vesnicancz/reality-scraper:latest
+ghcr.io/vesnicancz/reality-scraper:test     # poslední build (workflow „Build and push image (test)")
+ghcr.io/vesnicancz/reality-scraper:stable   # otestovaný build pro produkci
 ```
 
-Kontejner běží pod neprivilegovaným uživatelem, exponuje port `5000` a obsahuje health check.
+Každý build navíc dostane neměnný tag `:sha-<short>` podle commitu. Tok: build → `:test` (+ `:sha-…`); po
+otestování workflow „Promote image to stable" přeznačí stejný digest na `:stable` (bez rebuildu). Test
+prostředí tedy pulluje `:test`, produkce `:stable`.
+
+Kontejner běží pod neprivilegovaným uživatelem (UID 1654), exponuje port `5000` a obsahuje health check na `/health`.
 
 ## Testy
 

--- a/RealityScraper.slnx
+++ b/RealityScraper.slnx
@@ -5,7 +5,7 @@
     <File Path=".gitignore" />
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
-    <File Path="Dockerfile.publish" />
+    <File Path="Dockerfile" />
     <File Path="global.json" />
     <File Path="LICENSE" />
     <File Path="README.md" />


### PR DESCRIPTION
## Co to dělá

Ladění GitHub Actions CI a Docker buildu + zavedení image promotion mezi test a prod.

### Docker
- **Multi-stage `Dockerfile`** — build ze zdrojáků uvnitř `sdk:10.0` → runtime `aspnet:10.0`. Image je samostatný a reprodukovatelný (už nespoléhá na host `./publish`). Restore-layer caching díky kopírování `.csproj` napřed.
- **Non-root podle MS konvence** — místo vlastního `appuser` se používá vestavěný uživatel `app` (UID 1654 / `$APP_UID`).

### CI (`dotnet.yml`)
- Build i test v **Release** (konzistence s publish pipeline).
- `permissions: contents: read`, `workflow_dispatch`, `timeout-minutes`.
- Výsledky testů (`.trx`) jako artifact.

### Publikace a promote
- **`publish.yml`** — build & push přes `docker/build-push-action` + buildx **GHA layer cache** + `metadata-action`. Každý build → `:test` + neměnný `:sha-<short>`.
- **`promote.yml`** (nový) — *build once, promote the same digest*: přeznačí otestovaný digest na `:stable` bez rebuildu (`docker buildx imagetools create`). Připravený `environment: production` hook pro schvalovací bránu (aktivuje se přidáním required reviewers v Settings → Environments).

### Drobnosti
- `assign-pr-author.yml`: `actions/github-script@v7 → v8`.
- `RealityScraper.slnx`: oprava mrtvého odkazu `Dockerfile.publish` → `Dockerfile`.
- `README.md`: dokumentace `:test` / `:stable` schématu.

## Ověření
- ✅ `dotnet build -c Release` celé solution (0 warnings, 0 errors).
- ✅ `docker build` multi-stage image proběhl lokálně.
- ✅ Smoke test proti throwaway Postgresu: app naběhla, migrace proběhly, `/health` → 200, běh pod UID 1654, `/app/files` zapisovatelné.

## Pozn. k nasazení
Deploy definice na serverech (mimo repo) je potřeba přepnout z `:latest` na `:test` (test prostředí) a `:stable` (produkce). Přeznačení tagu samo nerestartuje běžící kontejner — server musí image znovu pullnout.
