### PR TITLE
Fix: Blazor FE 404 na blazor.web.js (regrese z #78)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,8 @@
 **/node_modules
 **/npm-debug.log
 **/obj
+**/publish
+**/TestResults
 **/secrets.dev.yaml
 **/values.dev.yaml
 LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,13 @@
 # syntax=docker/dockerfile:1
 
-# --- Build stage: restore + publish from source ---
+# --- Build stage: publish from source ---
+# Note: a single COPY + publish is intentional. Splitting into a csproj-only
+# restore layer (for caching) breaks Blazor static web asset composition and
+# drops _framework/blazor.web.js from the published output.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
-
-# Copy central build/package configuration first so the restore layer is cached
-# until one of these (or a .csproj below) actually changes.
-COPY global.json Directory.Build.props Directory.Packages.props ./
-
-# Copy every project file in Web.Api's graph so restore resolves the full set.
-COPY Application/Application.csproj Application/
-COPY Domain/Domain.csproj Domain/
-COPY SharedKernel/SharedKernel.csproj SharedKernel/
-COPY Infrastructure/Infrastructure.csproj Infrastructure/
-COPY Web.Api/Web.Api.csproj Web.Api/
-COPY Web.Client/Web.Client.csproj Web.Client/
-COPY Web.Shared/Web.Shared.csproj Web.Shared/
-
-RUN dotnet restore Web.Api/Web.Api.csproj
-
-# Copy the rest of the sources and publish (also builds the Blazor WASM client).
 COPY . .
-RUN dotnet publish Web.Api/Web.Api.csproj -c Release -o /app/publish --no-restore /p:UseAppHost=false
+RUN dotnet publish Web.Api/Web.Api.csproj -c Release -o /app/publish /p:UseAppHost=false
 
 # --- Runtime stage ---
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime


### PR DESCRIPTION
## Fix: Blazor FE nenaběhne — `_framework/blazor.web.js` 404/500

Regrese z #78. Multi-stage `Dockerfile` v #78 používal caching trik s rozděleným restorem (kopírovat jen `.csproj` → `dotnet restore` → `COPY . .` → `dotnet publish --no-restore`). Ten **rozbíjí kompozici Blazor static web assets** — z publishe vypadne `_framework/blazor.web.js` (a `blazor.server.js`), takže Blazor frontend spadne na 404/500 při načítání `blazor.web.js`. Klientské WASM assety projdou, proto API i `/health` fungují — frontend ne.

### Oprava
- `Dockerfile`: jeden `COPY . .` → `dotnet publish` (Microsoft-doporučený Blazor pattern), bez split-restore. Multi-stage i non-root UID 1654 zůstávají.
- `.dockerignore`: přidáno `publish/` a `TestResults/` (build kontext byl zbytečně ~150 MB).

### Ověření (běžící kontejner + throwaway Postgres)
- ✅ `GET /_framework/blazor.web.js` → **200** (předtím 500/404)
- ✅ `blazor.web.js` i `blazor.server.js` fyzicky v publishi
- ✅ `app.css`, klientské styly, `dotnet.js`, `/health` → 200
- ✅ běh pod UID 1654, migrace proti Postgresu proběhly
