### PR TITLE
NuGet update + pin Microsoft.OpenApi 2.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,34 +12,36 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="Havit.Blazor.Components.Web.Bootstrap" Version="4.25.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <!-- Úmyslný pin: Microsoft.AspNetCore.OpenApi jinak transitivně resolvuje deprecated/zranitelnou verzi Microsoft.OpenApi 2.0.0 (NU1903, GHSA-v5pm-xwqc-g5wc) -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="RazorEngineCore" Version="2026.1.1" />
-    <PackageVersion Include="Resend" Version="0.5.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.6" />
+    <PackageVersion Include="Resend" Version="0.6.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.12" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
-    <PackageVersion Include="Selenium.Support" Version="4.45.0" />
-    <PackageVersion Include="Selenium.WebDriver" Version="4.45.0" />
-    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="Selenium.Support" Version="4.46.0" />
+    <PackageVersion Include="Selenium.WebDriver" Version="4.46.0" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="WebDriverManager" Version="2.17.7" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Web.Api/Web.Api.csproj
+++ b/Web.Api/Web.Api.csproj
@@ -17,6 +17,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <!-- Přímá reference jen kvůli pinu novější verze, viz komentář v Directory.Packages.props -->
+    <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>


### PR DESCRIPTION
## Změny

Aktualizace NuGet balíčků:

- ASP.NET Core / EF Core / Microsoft.Extensions: 10.0.9 → 10.0.10
- Microsoft.NET.Test.Sdk 18.7.0 → 18.8.1, Npgsql.EntityFrameworkCore.PostgreSQL 10.0.2 → 10.0.3, Resend 0.5.1 → 0.6.0, Scalar.AspNetCore 2.16.6 → 2.16.12, Selenium 4.45.0 → 4.46.0, Serilog 4.3.1 → 4.4.0

Navíc přidán úmyslný přímý pin **Microsoft.OpenApi 2.11.0** ve Web.Api — `Microsoft.AspNetCore.OpenApi` má otevřený rozsah `[2.0.0, )`, takže bez pinu se transitivně resolvuje verze 2.0.0, která je deprecated (CriticalBugs) a má známou high-severity zranitelnost (NU1903, GHSA-v5pm-xwqc-g5wc).

## Ověření

- `dotnet restore` bez NU1903, `dotnet list package --deprecated --include-transitive` ve Web.Api nehlásí žádný zastaralý balíček
- build celé solution prošel, unit testy prošly (Application 18/18, Infrastructure 1/1)
- binární kompatibilita Microsoft.OpenApi 2.11.0 s Microsoft.AspNetCore.OpenApi 10.0.10 ověřena minimální aplikací — `/openapi/v1.json` vrací validní OpenAPI 3.1.1 dokument