### PR TITLE
Fix: počty inzerátů v reportu a robustnější detekce vyřazených

### DIFF
--- a/Application.Tests/Features/Scraping/Builders/ScrapingReportBuilderTests.cs
+++ b/Application.Tests/Features/Scraping/Builders/ScrapingReportBuilderTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using RealityScraper.Application.Features.Scraping.Builders;
 using RealityScraper.Application.Features.Scraping.Model;
 using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.Domain.Entities.Realty;
 using RealityScraper.SharedKernel;
 
 namespace RealityScraper.Application.Tests.Features.Scraping.Builders;
@@ -54,6 +55,90 @@ public class ScrapingReportBuilderTests
 
 		Assert.Equal(1, result.NewListingsCount);
 		Assert.Equal(1, result.TotalListingsCount);
+	}
+
+	[Fact]
+	public async Task ScrapingReportBuilder_ProcessScraperResults_SameExternalIdOnDifferentSitesIsNotDeduplicated()
+	{
+		// arrange
+		var listings1 = new List<ScraperListingItem>
+		{
+			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U1", ExternalId = "Ext1", ImageUrl = string.Empty }
+		};
+
+		var listings2 = new List<ScraperListingItem>
+		{
+			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U2", ExternalId = "Ext1", ImageUrl = string.Empty }
+		};
+
+		var sut = CreateBuilder();
+		sut.ForScrapingReport(Guid.NewGuid(), "task");
+
+		// act
+		await sut.ProcessScraperResultsAsync("siteA", new ScraperRunResult(true, listings1), CancellationToken.None);
+		await sut.ProcessScraperResultsAsync("siteB", new ScraperRunResult(true, listings2), CancellationToken.None);
+		var result = sut.Build();
+
+		// assert
+		Assert.Equal(2, result.NewListingsCount);
+		Assert.Equal(2, result.TotalListingsCount);
+		Assert.All(result.Results, r => Assert.Equal(1, r.TotalListingsCount));
+		Assert.Equal(new HashSet<string> { "Ext1" }, result.SeenExternalIds);
+	}
+
+	[Fact]
+	public async Task ScrapingReportBuilder_ProcessScraperResults_TotalCountSumsAcrossTargetsOfSameSite()
+	{
+		// arrange
+		var listings1 = new List<ScraperListingItem>
+		{
+			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U1", ExternalId = "Ext1", ImageUrl = string.Empty },
+			new ScraperListingItem { Title = "T2", Price = 2000, Location = "L2", Url = "U2", ExternalId = "Ext2", ImageUrl = string.Empty }
+		};
+
+		var listings2 = new List<ScraperListingItem>
+		{
+			new ScraperListingItem { Title = "T3", Price = 3000, Location = "L3", Url = "U3", ExternalId = "Ext3", ImageUrl = string.Empty }
+		};
+
+		var sut = CreateBuilder();
+		sut.ForScrapingReport(Guid.NewGuid(), "task");
+
+		// act
+		await sut.ProcessScraperResultsAsync("siteName", new ScraperRunResult(true, listings1), CancellationToken.None);
+		await sut.ProcessScraperResultsAsync("siteName", new ScraperRunResult(true, listings2), CancellationToken.None);
+		var result = sut.Build();
+
+		// assert
+		Assert.Equal(3, result.TotalListingsCount);
+		Assert.Equal(3, result.NewListingsCount);
+	}
+
+	[Fact]
+	public async Task ScrapingReportBuilder_ProcessScraperResults_UnchangedExistingListingCountsIntoTotal()
+	{
+		// arrange
+		var listings = new List<ScraperListingItem>
+		{
+			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U1", ExternalId = "Ext1", ImageUrl = string.Empty }
+		};
+
+		var listingRepositoryMock = new Mock<IListingRepository>();
+		listingRepositoryMock
+			.Setup(r => r.GetByExternalIdAsync(It.IsAny<Guid>(), "Ext1", It.IsAny<CancellationToken>()))
+			.ReturnsAsync(new Listing { ExternalId = "Ext1", Price = 1000 });
+
+		var sut = new ScrapingReportBuilder(listingRepositoryMock.Object, new Mock<IDateTimeProvider>().Object, new Mock<ILogger<ScrapingReportBuilder>>().Object);
+		sut.ForScrapingReport(Guid.NewGuid(), "task");
+
+		// act
+		await sut.ProcessScraperResultsAsync("siteName", new ScraperRunResult(true, listings), CancellationToken.None);
+		var result = sut.Build();
+
+		// assert
+		Assert.Equal(1, result.TotalListingsCount);
+		Assert.Equal(0, result.NewListingsCount);
+		Assert.Equal(0, result.PriceChangedListingsCount);
 	}
 
 	[Fact]

--- a/Application.Tests/Features/Scraping/RemovedListingDetectorTests.cs
+++ b/Application.Tests/Features/Scraping/RemovedListingDetectorTests.cs
@@ -43,11 +43,17 @@ public class RemovedListingDetectorTests
 
 	private static ScrapingReport CreateReport(Guid taskId, bool succeeded, params string[] seenExternalIds)
 	{
+		return CreateReport(taskId, succeeded, new List<PortalReport>(), seenExternalIds);
+	}
+
+	private static ScrapingReport CreateReport(Guid taskId, bool succeeded, List<PortalReport> results, params string[] seenExternalIds)
+	{
 		return new ScrapingReport
 		{
 			ScraperTaskId = taskId,
 			TaskName = "task",
 			ScrapingSucceeded = succeeded,
+			Results = results,
 			SeenExternalIds = new HashSet<string>(seenExternalIds)
 		};
 	}
@@ -113,17 +119,78 @@ public class RemovedListingDetectorTests
 	}
 
 	[Fact]
-	public async Task DetectAsync_ScrapingFailed_NothingIsChanged()
+	public async Task DetectAsync_ScrapingFailed_SeenListingIsUpdatedButNothingIsRemoved()
 	{
 		// arrange
 		var taskId = Guid.NewGuid();
+		var unseen = CreateListing("Unseen");
+		var seen = CreateListing("Seen");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(taskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([unseen, seen]);
+
 		var sut = CreateSut();
 
 		// act
-		await sut.DetectAsync(CreateReport(taskId, succeeded: false), CancellationToken.None);
+		await sut.DetectAsync(CreateReport(taskId, succeeded: false, "Seen"), CancellationToken.None);
 
 		// assert
-		listingRepositoryMock.Verify(x => x.GetByScraperTaskIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+		Assert.Equal(Now, seen.LastSeenAt);
+		Assert.Null(unseen.RemovedAt);
+		Assert.Equal(Earlier, unseen.LastSeenAt);
+	}
+
+	[Fact]
+	public async Task DetectAsync_PortalReturnedZeroListings_SeenListingIsUpdatedButNothingIsRemoved()
+	{
+		// arrange
+		var taskId = Guid.NewGuid();
+		var unseen = CreateListing("Unseen");
+		var seen = CreateListing("Seen");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(taskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([unseen, seen]);
+
+		var results = new List<PortalReport>
+		{
+			new PortalReport { SiteName = "PortalA", TotalListingsCount = 1 },
+			new PortalReport { SiteName = "PortalB", TotalListingsCount = 0 }
+		};
+
+		var sut = CreateSut();
+
+		// act
+		await sut.DetectAsync(CreateReport(taskId, succeeded: true, results, "Seen"), CancellationToken.None);
+
+		// assert
+		Assert.Equal(Now, seen.LastSeenAt);
+		Assert.Null(unseen.RemovedAt);
+	}
+
+	[Fact]
+	public async Task DetectAsync_AllPortalsReturnedListings_UnseenListingIsRemoved()
+	{
+		// arrange
+		var taskId = Guid.NewGuid();
+		var unseen = CreateListing("Unseen");
+		var seen = CreateListing("Seen");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(taskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([unseen, seen]);
+
+		var results = new List<PortalReport>
+		{
+			new PortalReport { SiteName = "PortalA", TotalListingsCount = 1 },
+			new PortalReport { SiteName = "PortalB", TotalListingsCount = 3 }
+		};
+
+		var sut = CreateSut();
+
+		// act
+		await sut.DetectAsync(CreateReport(taskId, succeeded: true, results, "Seen"), CancellationToken.None);
+
+		// assert
+		Assert.Equal(Now, unseen.RemovedAt);
 	}
 
 	[Fact]

--- a/Application/Features/Scraping/Builders/ScraperResultBuilder.cs
+++ b/Application/Features/Scraping/Builders/ScraperResultBuilder.cs
@@ -8,24 +8,29 @@ public class ScraperResultBuilder
 	private readonly List<ListingItem> newListings = new();
 	private readonly List<ListingItemWithNewPrice> priceChangedListings = new();
 	private int totalCount = 0;
-	private int listingsCount = 0;
 
-	public ScraperResultBuilder(string siteName, int listingsCount)
+	public ScraperResultBuilder(string siteName)
 	{
 		this.siteName = siteName;
-		this.listingsCount = listingsCount;
 	}
 
 	public ScraperResultBuilder AddNewListing(ListingItem listing)
 	{
 		newListings.Add(listing);
-		totalCount++;
 		return this;
 	}
 
 	public ScraperResultBuilder AddPriceChangedListing(ListingItemWithNewPrice listing)
 	{
 		priceChangedListings.Add(listing);
+		return this;
+	}
+
+	/// <summary>
+	/// Započítá jeden unikátní scrapovaný inzerát do celkového počtu (nový, se změnou ceny i beze změny).
+	/// </summary>
+	public ScraperResultBuilder IncrementTotalCount()
+	{
 		totalCount++;
 		return this;
 	}
@@ -35,7 +40,7 @@ public class ScraperResultBuilder
 		return new PortalReport
 		{
 			SiteName = siteName,
-			TotalListingsCount = listingsCount,
+			TotalListingsCount = totalCount,
 			NewListings = new List<ListingItem>(newListings),
 			PriceChangedListings = new List<ListingItemWithNewPrice>(priceChangedListings)
 		};

--- a/Application/Features/Scraping/Builders/ScrapingReportBuilder.cs
+++ b/Application/Features/Scraping/Builders/ScrapingReportBuilder.cs
@@ -12,7 +12,8 @@ public class ScrapingReportBuilder
 	private string scraperTaskName = string.Empty;
 	private bool allScrapersSucceeded = true;
 	private readonly Dictionary<string, ScraperResultBuilder> scraperBuilders = new();
-	private readonly HashSet<string> processedListings = new(); // Prevence duplikátů
+	private readonly HashSet<string> processedListings = new(); // Klíč "siteName|externalId" - prevence duplikátů mezi targety téhož portálu
+	private readonly HashSet<string> seenExternalIds = new();
 
 	private readonly IListingRepository listingRepository;
 	private readonly IDateTimeProvider dateTimeProvider;
@@ -35,6 +36,7 @@ public class ScrapingReportBuilder
 		allScrapersSucceeded = true;
 		scraperBuilders.Clear();
 		processedListings.Clear();
+		seenExternalIds.Clear();
 		return this;
 	}
 
@@ -60,7 +62,7 @@ public class ScrapingReportBuilder
 			allScrapersSucceeded = false;
 		}
 
-		var builder = GetOrCreateScraperBuilder(siteName, listings.Count);
+		var builder = GetOrCreateScraperBuilder(siteName);
 
 		foreach (var listing in listings)
 		{
@@ -75,8 +77,8 @@ public class ScrapingReportBuilder
 	/// </summary>
 	private async Task<ScrapingReportBuilder> ProcessListingAsync(ScraperResultBuilder builder, string siteName, ScraperListingItem listing, CancellationToken cancellationToken)
 	{
-		// Prevence duplikátů mezi scrapery
-		var listingKey = listing.ExternalId;
+		// Prevence duplikátů mezi targety téhož portálu
+		var listingKey = $"{siteName}|{listing.ExternalId}";
 		if (processedListings.Contains(listingKey))
 		{
 			logger.LogDebug("Duplikátní listing {ExternalId} přeskočen", listing.ExternalId);
@@ -123,15 +125,17 @@ public class ScrapingReportBuilder
 			// Existující bez změn - jen započítáme do celkového počtu
 		}
 
+		builder.IncrementTotalCount();
 		processedListings.Add(listingKey);
+		seenExternalIds.Add(listing.ExternalId);
 		return this;
 	}
 
-	private ScraperResultBuilder GetOrCreateScraperBuilder(string siteName, int listingsCount)
+	private ScraperResultBuilder GetOrCreateScraperBuilder(string siteName)
 	{
 		if (!scraperBuilders.ContainsKey(siteName))
 		{
-			scraperBuilders[siteName] = new ScraperResultBuilder(siteName, listingsCount);
+			scraperBuilders[siteName] = new ScraperResultBuilder(siteName);
 		}
 		return scraperBuilders[siteName];
 	}
@@ -152,7 +156,7 @@ public class ScrapingReportBuilder
 			TaskName = scraperTaskName,
 			Results = results,
 			ScrapingSucceeded = allScrapersSucceeded,
-			SeenExternalIds = new HashSet<string>(processedListings)
+			SeenExternalIds = new HashSet<string>(seenExternalIds)
 		};
 	}
 }

--- a/Application/Features/Scraping/RemovedListingDetector.cs
+++ b/Application/Features/Scraping/RemovedListingDetector.cs
@@ -23,27 +23,12 @@ public class RemovedListingDetector : IRemovedListingDetector
 
 	public async Task DetectAsync(ScrapingReport report, CancellationToken cancellationToken)
 	{
-		if (!report.ScrapingSucceeded)
-		{
-			logger.LogWarning("Scrapování úlohy '{TaskName}' neproběhlo celé úspěšně, detekce vyřazených inzerátů se přeskakuje.", report.TaskName);
-			return;
-		}
-
 		var listings = await listingRepository.GetByScraperTaskIdAsync(report.ScraperTaskId, cancellationToken);
-		var activeListings = listings.Where(l => l.RemovedAt == null).ToList();
-
-		// Ochrana proti planému poplachu: úspěšný běh s nula inzeráty při neprázdné DB
-		// spíš znamená rozbité selektory než skutečně prázdný portál.
-		if (report.SeenExternalIds.Count == 0 && activeListings.Count > 0)
-		{
-			logger.LogWarning("Scrapování úlohy '{TaskName}' nevrátilo žádné inzeráty, ale v databázi je {Count} aktivních. Detekce vyřazených se přeskakuje.", report.TaskName, activeListings.Count);
-			return;
-		}
-
 		var now = dateTimeProvider.UtcNow;
-		var removedCount = 0;
 		var reappearedCount = 0;
 
+		// Viděný inzerát prokazatelně existuje, takže LastSeenAt (a případný návrat
+		// vyřazeného) se aktualizuje i při částečném selhání scrapování.
 		foreach (var listing in listings)
 		{
 			if (report.SeenExternalIds.Contains(listing.ExternalId))
@@ -56,7 +41,41 @@ public class RemovedListingDetector : IRemovedListingDetector
 					logger.LogInformation("Inzerát {ExternalId} se znovu objevil.", listing.ExternalId);
 				}
 			}
-			else if (listing.RemovedAt == null)
+		}
+
+		if (!report.ScrapingSucceeded)
+		{
+			logger.LogWarning("Scrapování úlohy '{TaskName}' neproběhlo celé úspěšně, detekce vyřazených inzerátů se přeskakuje.", report.TaskName);
+			return;
+		}
+
+		var activeListings = listings.Where(l => l.RemovedAt == null).ToList();
+
+		// Ochrana proti planému poplachu: úspěšný běh s nula inzeráty při neprázdné DB
+		// spíš znamená rozbité selektory než skutečně prázdný portál. Kontroluje se
+		// každý portál zvlášť - inzeráty v DB nenesou informaci o portálu, takže
+		// prázdný výsledek kteréhokoli z nich by mohl chybně vyřadit jeho inzeráty.
+		if (activeListings.Count > 0)
+		{
+			if (report.SeenExternalIds.Count == 0)
+			{
+				logger.LogWarning("Scrapování úlohy '{TaskName}' nevrátilo žádné inzeráty, ale v databázi je {Count} aktivních. Detekce vyřazených se přeskakuje.", report.TaskName, activeListings.Count);
+				return;
+			}
+
+			var emptyPortals = report.Results.Where(r => r.TotalListingsCount == 0).Select(r => r.SiteName).ToList();
+			if (emptyPortals.Count > 0)
+			{
+				logger.LogWarning("Scrapování úlohy '{TaskName}': portály {Portals} nevrátily žádné inzeráty, ale v databázi je {Count} aktivních. Detekce vyřazených se přeskakuje.", report.TaskName, string.Join(", ", emptyPortals), activeListings.Count);
+				return;
+			}
+		}
+
+		var removedCount = 0;
+
+		foreach (var listing in listings)
+		{
+			if (!report.SeenExternalIds.Contains(listing.ExternalId) && listing.RemovedAt == null)
 			{
 				listing.RemovedAt = now;
 				removedCount++;


### PR DESCRIPTION
## Souhrn

Oprava chybného celkového počtu scrapovaných inzerátů v e-mailovém reportu a dvou souvisejících slabých míst ve stejné části pipeline.

### 1. Celkový počet inzerátů za portál (hlavní bug)

`ScraperResultBuilder` dostával počet inzerátů konstruktorem při prvním batchi — když měl portál v úloze víc targetů (URL), počty z dalších targetů se zahodily a v mailu bylo jen číslo z prvního. Nově se celkový počet počítá průběžně v `ProcessListingAsync` pro každý unikátní zpracovaný inzerát (nový, změna ceny i beze změny), takže správně sčítá přes všechny targety a nedvojí duplikáty.

### 2. Deduplikace klíčovaná per portál

Prevence duplikátů používala holé `ExternalId` napříč portály — případná shoda ID mezi dvěma portály by inzerát z druhého portálu tiše zahodila. Klíč je nyní `siteName|externalId`; pro `SeenExternalIds` (porovnávané proti DB) zůstává oddělená množina holých ID.

### 3. Detekce vyřazených: per-portálová pojistka

Ochrana proti planému poplachu kontrolovala jen nulový počet za celou úlohu. Když jednomu portálu přestaly fungovat selektory (scraper skončí „úspěšně" s 0 inzeráty), ale druhý portál data vrátil, všechny inzeráty prvního portálu se chybně označily jako vyřazené. Nově se detekce přeskočí, pokud kterýkoli portál vrátil 0 inzerátů při neprázdné DB.

### 4. Aktualizace `LastSeenAt` i při částečném selhání

Aktualizace `LastSeenAt` (a návrat dříve vyřazených inzerátů) se přesunula před pojistky detektoru — viděný inzerát prokazatelně existuje, takže se aktualizuje vždy; při selhání se přeskakuje jen samotné označování vyřazených.

## Testy

- 5 nových testů (součet přes targety, započítání nezměněného inzerátu, dedup napříč portály, prázdný portál blokuje vyřazení, neprázdné portály vyřazení provedou)
- 1 test přepsán na nové chování (`DetectAsync_ScrapingFailed_*` — dřív ověřoval, že se při selhání nesáhne do DB)
- Všech 23 testů v `Application.Tests` prochází, solution se builduje bez warningů