### PR TITLE
Feature: vizuální redesign e-mailových reportů

### DIFF
--- a/Infrastructure.Tests/Utilities/Mailing/RazorEmailGeneratorTests.cs
+++ b/Infrastructure.Tests/Utilities/Mailing/RazorEmailGeneratorTests.cs
@@ -1,12 +1,15 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using RazorEngineCore;
 using RealityScraper.Application.Features.Reporting.Model;
+using RealityScraper.Application.Features.Scraping.Model.Report;
 using RealityScraper.Infrastructure.Utilities.Mailing;
 
 namespace RealityScraper.Infrastructure.Tests.Utilities.Mailing;
 
 public class RazorEmailGeneratorTests
 {
+	private const string PlaceholderImageUri = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='180'><rect width='100%25' height='100%25' fill='%23cbd5e1'/></svg>";
+
 	[Fact]
 	public async Task GenerateRemovedListingsHtmlAsync_RendersTemplate()
 	{
@@ -60,7 +63,118 @@ public class RazorEmailGeneratorTests
 		Assert.Contains("Domy u Brna", html);
 		Assert.Contains($"cid:{listingWithImage.ListingId}", html);
 		Assert.DoesNotContain($"cid:{listingWithoutImage.ListingId}", html);
+		Assert.Contains("Prodej domu", html);
 		Assert.Contains("Vesnice u Brna", html);
 		Assert.Contains("12.07.2026", html);
+		Assert.Contains("Můj report", html);
+		Assert.Contains("sledováno 41 dní", html);
+		Assert.Contains("sledováno 70 dní", html);
+		Assert.Contains("Již nedostupné", html);
+		Assert.Contains("property-image-placeholder", html);
+
+		WritePreviewFile("preview-RemovedListingsReport.html", html.Replace($"cid:{listingWithImage.ListingId}", PlaceholderImageUri));
+	}
+
+	[Fact]
+	public async Task GenerateHtmlBodyAsync_RendersTemplate()
+	{
+		// arrange
+		var newListing = new ListingItem
+		{
+			Title = "Prodej domu 4+1",
+			Location = "Vesnice u Brna",
+			Price = 4_500_000,
+			Url = "https://example.com/inzerat/1",
+			ImageUrl = "https://example.com/obrazek/1.jpg",
+			ExternalId = "ext-1"
+		};
+
+		var priceChangedListing = new ListingItemWithNewPrice
+		{
+			Title = "Prodej bytu 2+kk",
+			Location = "Brno",
+			Price = 2_900_000,
+			OldPrice = 3_100_000,
+			Url = "https://example.com/inzerat/2",
+			ImageUrl = string.Empty,
+			ExternalId = "ext-2"
+		};
+
+		var report = new ScrapingReport
+		{
+			ReportDate = new DateTimeOffset(2026, 7, 13, 6, 0, 0, TimeSpan.Zero),
+			TaskName = "Domy okres Brno",
+			ScrapingSucceeded = true,
+			Results =
+			[
+				new PortalReport
+				{
+					SiteName = "Sreality",
+					TotalListingsCount = 12,
+					NewListings = [newListing],
+					PriceChangedListings = [priceChangedListing]
+				}
+			]
+		};
+
+		var sut = new RazorEmailGenerator(new RazorEngine(), NullLogger<RazorEmailGenerator>.Instance);
+
+		// act
+		var html = await sut.GenerateHtmlBodyAsync(report, CancellationToken.None);
+
+		// assert
+		Assert.Contains("Domy okres Brno", html);
+		Assert.Contains("Sreality", html);
+		Assert.Contains("Prodej domu 4+1", html);
+		Assert.Contains("Vesnice u Brna", html);
+		Assert.Contains("Prodej bytu 2+kk", html);
+		Assert.Contains(newListing.ImageUrl, html);
+		Assert.Contains("&#8595;", html); // šipka dolů u poklesu ceny
+		Assert.Contains("(-6,5 %)", html);
+		Assert.Contains("původně", html);
+		Assert.Contains("property-image-placeholder", html); // změněná nabídka bez obrázku
+
+		WritePreviewFile("preview-ListingReport.html", html.Replace(newListing.ImageUrl, PlaceholderImageUri));
+	}
+
+	[Fact]
+	public void Templates_SharedStylesAreInSync()
+	{
+		// arrange
+		var listingReport = ReadTemplateFile("ListingReport.cshtml");
+		var removedListingsReport = ReadTemplateFile("RemovedListingsReport.cshtml");
+
+		// act
+		var listingReportStyles = ExtractSharedStyles(listingReport);
+		var removedListingsReportStyles = ExtractSharedStyles(removedListingsReport);
+
+		// assert
+		Assert.Equal(listingReportStyles, removedListingsReportStyles);
+	}
+
+	private static string ReadTemplateFile(string fileName)
+	{
+		var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Utilities", "Mailing", "Templates", fileName);
+		return File.ReadAllText(path);
+	}
+
+	private static string ExtractSharedStyles(string templateContent)
+	{
+		const string startToken = "/* SHARED EMAIL STYLES";
+		const string endToken = "/* END SHARED EMAIL STYLES */";
+
+		var start = templateContent.IndexOf(startToken, StringComparison.Ordinal);
+		Assert.True(start >= 0, $"Šablona neobsahuje značku '{startToken}'.");
+
+		var startLineEnd = templateContent.IndexOf('\n', start);
+		var end = templateContent.IndexOf(endToken, StringComparison.Ordinal);
+		Assert.True(end > startLineEnd, $"Šablona neobsahuje značku '{endToken}'.");
+
+		return templateContent.Substring(startLineEnd + 1, end - startLineEnd - 1);
+	}
+
+	private static void WritePreviewFile(string fileName, string html)
+	{
+		File.WriteAllText(Path.Combine(AppContext.BaseDirectory, fileName), html);
 	}
 }

--- a/Infrastructure/Utilities/Mailing/Templates/ListingReport.cshtml
+++ b/Infrastructure/Utilities/Mailing/Templates/ListingReport.cshtml
@@ -1,24 +1,31 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="cs">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="color-scheme" content="light">
+	<meta name="supported-color-schemes" content="light">
 	<title>Notifikace změn na realitních serverech</title>
 	<style>
+		/* SHARED EMAIL STYLES — keep in sync with RemovedListingsReport.cshtml */
 		* {
 			margin: 0;
 			padding: 0;
 			box-sizing: border-box;
 		}
 
+		:root {
+			color-scheme: light;
+		}
+
 		body {
 			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 			line-height: 1.5;
 			color: #1f2937;
-			max-width: 800px;
+			max-width: 640px;
 			margin: 0 auto;
 			padding: 20px;
-			background-color: #edeef0;
+			background-color: #f1f2f4;
 		}
 
 		.header {
@@ -26,73 +33,87 @@
 			margin-bottom: 24px;
 		}
 
+		.header .eyebrow {
+			color: #6b7280;
+			font-size: 12px;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 2px;
+			margin-bottom: 4px;
+		}
+
 		.header h1 {
-			color: #2563eb;
 			font-size: 24px;
 			font-weight: 700;
-			margin-bottom: 8px;
+			margin-bottom: 6px;
 		}
 
 		.header p {
 			color: #6b7280;
-			font-size: 16px;
+			font-size: 15px;
 		}
 
 		.summary {
-			background-color: white;
+			background-color: #ffffff;
+			color: #1f2937;
 			padding: 16px;
 			margin-bottom: 24px;
-			border-radius: 8px;
-			box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-			border-left: 4px solid #3b82f6;
+			border: 1px solid #e5e7eb;
+			border-radius: 10px;
 		}
 
 		.portal-section {
-			background-color: white;
+			background-color: #ffffff;
 			margin-bottom: 24px;
-			border-radius: 8px;
+			border: 1px solid #e5e7eb;
+			border-radius: 10px;
 			overflow: hidden;
-			box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
 		}
 
 		.portal-header {
-			display: flex;
-			align-items: center;
-			padding: 16px;
-			background-color: #3b82f6;
-			background: linear-gradient(to right, #3b82f6, #2563eb);
-			color: white;
-			justify-content: space-between;
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		.portal-header td {
+			padding: 14px 16px;
 		}
 
 		.portal-header h2 {
+			color: #ffffff;
 			font-size: 18px;
 			font-weight: 600;
 		}
 
 		.portal-header .count {
-			background-color: white;
-			color: #3b82f6;
+			background-color: #ffffff;
 			font-size: 14px;
+			font-weight: 600;
 			border-radius: 16px;
 			padding: 2px 10px;
 		}
 
 		.section-header {
-			padding: 14px 16px;
+			width: 100%;
+			border-collapse: collapse;
 			background-color: #f3f4f6;
+		}
+
+		.section-header td {
+			padding: 12px 16px;
+			border-bottom: 1px solid #e5e7eb;
+		}
+
+		.section-header .label {
 			font-weight: 600;
-			font-size: 16px;
-			border-bottom: 1px solid rgba(0,0,0,0.05);
+			font-size: 15px;
 			color: #1f2937;
-			display: flex;
-			justify-content: space-between;
 		}
 
 		.section-header .count {
-			background-color: #3b82f6;
-			color: white;
-			font-size: 14px;
+			color: #ffffff;
+			font-size: 13px;
+			font-weight: 600;
 			border-radius: 16px;
 			padding: 2px 10px;
 		}
@@ -105,130 +126,161 @@
 
 		.property-item {
 			padding: 16px;
-			border-bottom: 1px solid rgba(0,0,0,0.05);
+			border-bottom: 1px solid #e5e7eb;
 		}
 
 		.property-item:last-child {
 			border-bottom: none;
 		}
 
-		.property-content {
-			display: grid;
-			grid-template-columns: 160px 1fr;
-			gap: 16px;
+		.property-row {
+			width: 100%;
+			border-collapse: collapse;
 		}
 
-		.property-image-container {
-			position: relative;
-			overflow: hidden;
-			border-radius: 8px;
-			height: 120px;
+		.property-image-cell {
+			padding-right: 16px;
 		}
 
 		.property-image {
-			width: 100%;
-			height: 100%;
+			width: 120px;
+			height: 90px;
 			object-fit: cover;
-			transition: transform 0.3s ease;
+			border-radius: 8px;
+			display: block;
+			background-color: #e5e7eb;
 		}
 
-		.property-image:hover {
-			transform: scale(1.05);
-		}
-
-		.property-info {
-			display: flex;
-			flex-direction: column;
+		.property-image-placeholder {
+			width: 120px;
+			height: 90px;
+			border-radius: 8px;
+			background-color: #e5e7eb;
+			color: #9ca3af;
+			font-size: 30px;
+			text-align: center;
+			line-height: 90px;
 		}
 
 		.property-title {
 			font-weight: 600;
 			font-size: 16px;
-			margin-bottom: 8px;
 			color: #1f2937;
+			margin-bottom: 2px;
+		}
+
+		.property-location {
+			color: #6b7280;
+			font-size: 13px;
+			margin-bottom: 6px;
 		}
 
 		.property-price {
 			font-weight: 700;
 			font-size: 18px;
-			color: #2563eb;
-			margin-bottom: 8px;
-			display: flex;
-			align-items: center;
+			margin-bottom: 6px;
 		}
 
-		.price-change {
-			margin-left: 8px;
-			font-size: 14px;
-			font-weight: 500;
-			padding: 2px 8px;
-			border-radius: 4px;
+		.property-old-price {
+			color: #9ca3af;
+			font-size: 13px;
+			margin-bottom: 6px;
 		}
 
-		.price-down {
-			background-color: rgba(16, 185, 129, 0.1);
-			color: #10b981;
-		}
-
-		.price-up {
-			background-color: rgba(239, 68, 68, 0.1);
-			color: #ef4444;
+		.property-meta {
+			color: #6b7280;
+			font-size: 13px;
+			margin-bottom: 10px;
 		}
 
 		.property-link {
-			display: inline-flex;
-			align-items: center;
-			background-color: #3b82f6;
-			color: white !important;
+			display: inline-block;
+			color: #ffffff !important;
 			text-decoration: none;
 			padding: 8px 16px;
 			border-radius: 8px;
 			font-weight: 500;
 			font-size: 14px;
-			transition: background-color 0.2s;
-			margin-top: auto;
-			align-self: flex-start;
-		}
-
-		.property-link:hover {
-			background-color: #2563eb;
 		}
 
 		.footer {
 			text-align: center;
 			color: #6b7280;
-			font-size: 14px;
-			margin-top: 16px;
+			font-size: 13px;
+			margin-top: 8px;
 		}
 
-		.footer a {
-			color: #3b82f6;
-			text-decoration: none;
-		}
-
-		.footer a:hover {
-			text-decoration: underline;
-		}
-
-		@@media only screen and (max-width: 600px) {
+		@@media only screen and (max-width: 480px) {
 			body {
 				padding: 12px;
 			}
 
-			.property-content {
-				grid-template-columns: 1fr;
+			.header h1 {
+				font-size: 21px;
 			}
 
-			.property-image-container {
-				height: 180px;
-				margin-bottom: 8px;
+			.property-item {
+				padding: 12px;
 			}
+		}
+		/* END SHARED EMAIL STYLES */
+
+		/* ACCENT & REPORT-SPECIFIC STYLES (blue) */
+		.header h1 {
+			color: #2563eb;
+		}
+
+		.summary {
+			border-left: 4px solid #3b82f6;
+		}
+
+		.portal-header {
+			background-color: #2563eb;
+		}
+
+		.portal-header .count {
+			color: #2563eb;
+		}
+
+		.section-header .count {
+			background-color: #2563eb;
+		}
+
+		.property-price {
+			color: #2563eb;
+		}
+
+		.property-link {
+			background-color: #2563eb;
+		}
+
+		.price-change {
+			font-size: 13px;
+			font-weight: 600;
+			padding: 2px 8px;
+			border-radius: 10px;
+			margin-left: 6px;
+		}
+
+		.price-down {
+			background-color: #d1fae5;
+			color: #065f46;
+		}
+
+		.price-up {
+			background-color: #fef3c7;
+			color: #92400e;
 		}
 	</style>
 </head>
 <body>
 	<div class="header">
+		<p class="eyebrow">Realitní monitoring</p>
 		<h1>Notifikace realitních nabídek</h1>
+		@if (!string.IsNullOrWhiteSpace(Model.TaskName))
+		{
+			<p><strong>@Model.TaskName</strong></p>
+		}
 		<p>Přehled změn ze dne @Model.ReportDate.ToString("dd.MM.yyyy HH:mm")</p>
 	</div>
 
@@ -243,33 +295,50 @@
 	@foreach (var result in Model.GetNotEmptyResults())
 	{
 		<div class="portal-section">
-			<div class="portal-header">
-				<h2>@result.SiteName</h2>
-				<span class="count">@result.TotalListingsCount</span>
-			</div>
+			<table role="presentation" class="portal-header" width="100%" cellpadding="0" cellspacing="0">
+				<tr>
+					<td><h2>@result.SiteName</h2></td>
+					<td align="right"><span class="count">@result.TotalListingsCount</span></td>
+				</tr>
+			</table>
 
 			@if (result.NewListingsCount > 0)
 			{
 				<!-- Nové nabídky -->
-				<div class="section-header">
-					<span>Nové nabídky</span>
-					<span class="count">@result.NewListingsCount</span>
-				</div>
+				<table role="presentation" class="section-header" width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td class="label">Nové nabídky</td>
+						<td align="right"><span class="count">@result.NewListingsCount</span></td>
+					</tr>
+				</table>
 				<ul class="property-list">
 
 					@foreach (var listing in result.NewListings)
 					{
 						<li class="property-item">
-							<div class="property-content">
-								<div class="property-image-container">
-									<img src="@listing.ImageUrl" alt="@listing.Location" class="property-image">
-								</div>
-								<div class="property-info">
-									<div class="property-title">@listing.Location</div>
-									<div class="property-price">@FormatPrice(listing.Price)</div>
-									<a href="@listing.Url" class="property-link">Zobrazit detail</a>
-								</div>
-							</div>
+							<table role="presentation" class="property-row" width="100%" cellpadding="0" cellspacing="0">
+								<tr>
+									<td class="property-image-cell" width="136" valign="top">
+										@if (!string.IsNullOrEmpty(listing.ImageUrl))
+										{
+											<img src="@listing.ImageUrl" alt="@listing.Location" class="property-image">
+										}
+										else
+										{
+											<div class="property-image-placeholder">&#127968;</div>
+										}
+									</td>
+									<td valign="top">
+										<div class="property-title">@(string.IsNullOrWhiteSpace(listing.Title) ? listing.Location : listing.Title)</div>
+										@if (!string.IsNullOrWhiteSpace(listing.Title) && !string.IsNullOrWhiteSpace(listing.Location))
+										{
+											<div class="property-location">&#128205; @listing.Location</div>
+										}
+										<div class="property-price">@FormatPrice(listing.Price)</div>
+										<a href="@listing.Url" class="property-link">Zobrazit detail</a>
+									</td>
+								</tr>
+							</table>
 						</li>
 					}
 				</ul>
@@ -278,39 +347,51 @@
 			@if (result.PriceChangedListingsCount > 0)
 			{
 				<!-- Změny cen -->
-				<div class="section-header">
-					<span>Změny cen</span>
-					<span class="count">@result.PriceChangedListingsCount</span>
-				</div>
+				<table role="presentation" class="section-header" width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td class="label">Změny cen</td>
+						<td align="right"><span class="count">@result.PriceChangedListingsCount</span></td>
+					</tr>
+				</table>
 				<ul class="property-list">
 
 					@foreach (var listing in result.PriceChangedListings)
 					{
 						<li class="property-item">
-							<div class="property-content">
-								<div class="property-image-container">
-									<img src="@listing.ImageUrl" alt="@listing.Location" class="property-image">
-								</div>
-								<div class="property-info">
-									<div class="property-title">@listing.Location</div>
-									<div class="property-price">
-										@FormatPrice(listing.Price)
-										@if (listing.PriceDiff < 0)
+							<table role="presentation" class="property-row" width="100%" cellpadding="0" cellspacing="0">
+								<tr>
+									<td class="property-image-cell" width="136" valign="top">
+										@if (!string.IsNullOrEmpty(listing.ImageUrl))
 										{
-											<span class="price-change price-down">↓ @FormatPrice(listing.PriceDiff)</span>
-										}
-										else if (listing.PriceDiff > 0)
-										{
-											<span class="price-change price-up">↑ +@FormatPrice(listing.PriceDiff)</span>
+											<img src="@listing.ImageUrl" alt="@listing.Location" class="property-image">
 										}
 										else
 										{
-											<text>(původně @FormatPrice(listing.OldPrice))</text>
+											<div class="property-image-placeholder">&#127968;</div>
 										}
-									</div>
-									<a href="@listing.Url" class="property-link">Zobrazit detail</a>
-								</div>
-							</div>
+									</td>
+									<td valign="top">
+										<div class="property-title">@(string.IsNullOrWhiteSpace(listing.Title) ? listing.Location : listing.Title)</div>
+										@if (!string.IsNullOrWhiteSpace(listing.Title) && !string.IsNullOrWhiteSpace(listing.Location))
+										{
+											<div class="property-location">&#128205; @listing.Location</div>
+										}
+										<div class="property-price">
+											@FormatPrice(listing.Price)
+											@if (listing.PriceDiff < 0)
+											{
+												<span class="price-change price-down">&#8595; @FormatPrice(listing.PriceDiff)@FormatPercent(listing.PriceDiff, listing.OldPrice)</span>
+											}
+											else if (listing.PriceDiff > 0)
+											{
+												<span class="price-change price-up">&#8593; +@FormatPrice(listing.PriceDiff)@FormatPercent(listing.PriceDiff, listing.OldPrice)</span>
+											}
+										</div>
+										<div class="property-old-price"><s>původně @FormatPrice(listing.OldPrice)</s></div>
+										<a href="@listing.Url" class="property-link">Zobrazit detail</a>
+									</td>
+								</tr>
+							</table>
 						</li>
 					}
 				</ul>
@@ -366,6 +447,19 @@
 		else
 		{
 			return "neuvedeno";
+		}
+	}
+
+	string FormatPercent(decimal? diff, decimal? oldPrice)
+	{
+		if (diff.HasValue && oldPrice.HasValue && oldPrice.Value != 0)
+		{
+			var percent = System.Math.Round(diff.Value / oldPrice.Value * 100, 1);
+			return $" ({percent.ToString("+0.#;-0.#", System.Globalization.CultureInfo.GetCultureInfo("cs-CZ"))} %)";
+		}
+		else
+		{
+			return string.Empty;
 		}
 	}
 }

--- a/Infrastructure/Utilities/Mailing/Templates/RemovedListingsReport.cshtml
+++ b/Infrastructure/Utilities/Mailing/Templates/RemovedListingsReport.cshtml
@@ -3,22 +3,29 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="color-scheme" content="light">
+	<meta name="supported-color-schemes" content="light">
 	<title>Report zrušených realitních nabídek</title>
 	<style>
+		/* SHARED EMAIL STYLES — keep in sync with ListingReport.cshtml */
 		* {
 			margin: 0;
 			padding: 0;
 			box-sizing: border-box;
 		}
 
+		:root {
+			color-scheme: light;
+		}
+
 		body {
 			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 			line-height: 1.5;
 			color: #1f2937;
-			max-width: 800px;
+			max-width: 640px;
 			margin: 0 auto;
 			padding: 20px;
-			background-color: #edeef0;
+			background-color: #f1f2f4;
 		}
 
 		.header {
@@ -26,54 +33,87 @@
 			margin-bottom: 24px;
 		}
 
+		.header .eyebrow {
+			color: #6b7280;
+			font-size: 12px;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 2px;
+			margin-bottom: 4px;
+		}
+
 		.header h1 {
-			color: #dc2626;
 			font-size: 24px;
 			font-weight: 700;
-			margin-bottom: 8px;
+			margin-bottom: 6px;
 		}
 
 		.header p {
 			color: #6b7280;
-			font-size: 16px;
+			font-size: 15px;
 		}
 
 		.summary {
-			background-color: white;
+			background-color: #ffffff;
+			color: #1f2937;
 			padding: 16px;
 			margin-bottom: 24px;
-			border-radius: 8px;
-			box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-			border-left: 4px solid #ef4444;
+			border: 1px solid #e5e7eb;
+			border-radius: 10px;
 		}
 
 		.portal-section {
-			background-color: white;
+			background-color: #ffffff;
 			margin-bottom: 24px;
-			border-radius: 8px;
+			border: 1px solid #e5e7eb;
+			border-radius: 10px;
 			overflow: hidden;
-			box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
 		}
 
 		.portal-header {
-			display: flex;
-			align-items: center;
-			padding: 16px;
-			background-color: #ef4444;
-			background: linear-gradient(to right, #ef4444, #dc2626);
-			color: white;
-			justify-content: space-between;
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		.portal-header td {
+			padding: 14px 16px;
 		}
 
 		.portal-header h2 {
+			color: #ffffff;
 			font-size: 18px;
 			font-weight: 600;
 		}
 
 		.portal-header .count {
-			background-color: white;
-			color: #ef4444;
+			background-color: #ffffff;
 			font-size: 14px;
+			font-weight: 600;
+			border-radius: 16px;
+			padding: 2px 10px;
+		}
+
+		.section-header {
+			width: 100%;
+			border-collapse: collapse;
+			background-color: #f3f4f6;
+		}
+
+		.section-header td {
+			padding: 12px 16px;
+			border-bottom: 1px solid #e5e7eb;
+		}
+
+		.section-header .label {
+			font-weight: 600;
+			font-size: 15px;
+			color: #1f2937;
+		}
+
+		.section-header .count {
+			color: #ffffff;
+			font-size: 13px;
+			font-weight: 600;
 			border-radius: 16px;
 			padding: 2px 10px;
 		}
@@ -86,101 +126,154 @@
 
 		.property-item {
 			padding: 16px;
-			border-bottom: 1px solid rgba(0,0,0,0.05);
+			border-bottom: 1px solid #e5e7eb;
 		}
 
 		.property-item:last-child {
 			border-bottom: none;
 		}
 
-		.property-content {
-			display: grid;
-			grid-template-columns: 160px 1fr;
-			gap: 16px;
+		.property-row {
+			width: 100%;
+			border-collapse: collapse;
 		}
 
-		.property-content.no-image {
-			grid-template-columns: 1fr;
-		}
-
-		.property-image-container {
-			position: relative;
-			overflow: hidden;
-			border-radius: 8px;
-			height: 120px;
+		.property-image-cell {
+			padding-right: 16px;
 		}
 
 		.property-image {
-			width: 100%;
-			height: 100%;
+			width: 120px;
+			height: 90px;
 			object-fit: cover;
+			border-radius: 8px;
+			display: block;
+			background-color: #e5e7eb;
 		}
 
-		.property-info {
-			display: flex;
-			flex-direction: column;
+		.property-image-placeholder {
+			width: 120px;
+			height: 90px;
+			border-radius: 8px;
+			background-color: #e5e7eb;
+			color: #9ca3af;
+			font-size: 30px;
+			text-align: center;
+			line-height: 90px;
 		}
 
 		.property-title {
 			font-weight: 600;
 			font-size: 16px;
-			margin-bottom: 8px;
 			color: #1f2937;
+			margin-bottom: 2px;
+		}
+
+		.property-location {
+			color: #6b7280;
+			font-size: 13px;
+			margin-bottom: 6px;
 		}
 
 		.property-price {
 			font-weight: 700;
 			font-size: 18px;
-			color: #dc2626;
-			margin-bottom: 8px;
+			margin-bottom: 6px;
 		}
 
-		.property-dates {
+		.property-old-price {
+			color: #9ca3af;
+			font-size: 13px;
+			margin-bottom: 6px;
+		}
+
+		.property-meta {
 			color: #6b7280;
-			font-size: 14px;
-			margin-bottom: 8px;
+			font-size: 13px;
+			margin-bottom: 10px;
 		}
 
 		.property-link {
-			display: inline-flex;
-			align-items: center;
-			background-color: #6b7280;
-			color: white !important;
+			display: inline-block;
+			color: #ffffff !important;
 			text-decoration: none;
 			padding: 8px 16px;
 			border-radius: 8px;
 			font-weight: 500;
 			font-size: 14px;
-			margin-top: auto;
-			align-self: flex-start;
 		}
 
 		.footer {
 			text-align: center;
 			color: #6b7280;
-			font-size: 14px;
-			margin-top: 16px;
+			font-size: 13px;
+			margin-top: 8px;
 		}
 
-		@@media only screen and (max-width: 600px) {
+		@@media only screen and (max-width: 480px) {
 			body {
 				padding: 12px;
 			}
 
-			.property-content {
-				grid-template-columns: 1fr;
+			.header h1 {
+				font-size: 21px;
 			}
 
-			.property-image-container {
-				height: 180px;
-				margin-bottom: 8px;
+			.property-item {
+				padding: 12px;
 			}
+		}
+		/* END SHARED EMAIL STYLES */
+
+		/* ACCENT & REPORT-SPECIFIC STYLES (red) */
+		.header h1 {
+			color: #dc2626;
+		}
+
+		.summary {
+			border-left: 4px solid #ef4444;
+		}
+
+		.portal-header {
+			background-color: #dc2626;
+		}
+
+		.portal-header .count {
+			color: #dc2626;
+		}
+
+		.property-price {
+			color: #dc2626;
+		}
+
+		.property-link {
+			background-color: #6b7280;
+		}
+
+		.property-image {
+			filter: grayscale(60%);
+			opacity: 0.85;
+		}
+
+		.unavailable-badge {
+			background-color: #fee2e2;
+			color: #991b1b;
+			font-size: 12px;
+			font-weight: 600;
+			padding: 2px 8px;
+			border-radius: 10px;
+			margin-left: 6px;
 		}
 	</style>
 </head>
 <body>
 	<div class="header">
+		<p class="eyebrow">Realitní monitoring</p>
 		<h1>Zrušené realitní nabídky</h1>
+		@if (!string.IsNullOrWhiteSpace(Model.ReportName))
+		{
+			<p><strong>@Model.ReportName</strong></p>
+		}
 		<p>Období @Model.PeriodFrom.ToString("dd.MM.yyyy") – @Model.PeriodTo.ToString("dd.MM.yyyy")</p>
 	</div>
 
@@ -193,32 +286,41 @@
 	@foreach (var section in Model.Sections)
 	{
 		<div class="portal-section">
-			<div class="portal-header">
-				<h2>@section.ScraperTaskName</h2>
-				<span class="count">@section.Listings.Count</span>
-			</div>
+			<table role="presentation" class="portal-header" width="100%" cellpadding="0" cellspacing="0">
+				<tr>
+					<td><h2>@section.ScraperTaskName</h2></td>
+					<td align="right"><span class="count">@section.Listings.Count</span></td>
+				</tr>
+			</table>
 
 			<ul class="property-list">
 				@foreach (var listing in section.Listings)
 				{
 					<li class="property-item">
-						<div class="property-content @(listing.HasImage ? "" : "no-image")">
-							@if (listing.HasImage)
-							{
-								<div class="property-image-container">
-									<img src="cid:@listing.ListingId" alt="@listing.Location" class="property-image">
-								</div>
-							}
-							<div class="property-info">
-								<div class="property-title">@(string.IsNullOrWhiteSpace(listing.Location) ? listing.Title : listing.Location)</div>
-								<div class="property-price">@FormatPrice(listing.Price)</div>
-								<div class="property-dates">
-									Zrušeno: <strong>@(listing.RemovedAt?.ToString("dd.MM.yyyy") ?? "–")</strong>
-									&middot; sledováno od @listing.CreatedAt.ToString("dd.MM.yyyy")
-								</div>
-								<a href="@listing.Url" class="property-link">Původní odkaz (již nemusí fungovat)</a>
-							</div>
-						</div>
+						<table role="presentation" class="property-row" width="100%" cellpadding="0" cellspacing="0">
+							<tr>
+								<td class="property-image-cell" width="136" valign="top">
+									@if (listing.HasImage)
+									{
+										<img src="cid:@listing.ListingId" alt="@listing.Location" class="property-image">
+									}
+									else
+									{
+										<div class="property-image-placeholder">&#127968;</div>
+									}
+								</td>
+								<td valign="top">
+									<div class="property-title">@(string.IsNullOrWhiteSpace(listing.Title) ? listing.Location : listing.Title)</div>
+									@if (!string.IsNullOrWhiteSpace(listing.Title) && !string.IsNullOrWhiteSpace(listing.Location))
+									{
+										<div class="property-location">&#128205; @listing.Location</div>
+									}
+									<div class="property-price">@FormatPrice(listing.Price) <span class="unavailable-badge">Již nedostupné</span></div>
+									<div class="property-meta">@FormatRemovedMeta(listing.CreatedAt, listing.RemovedAt)</div>
+									<a href="@listing.Url" class="property-link">Původní odkaz (již nemusí fungovat)</a>
+								</td>
+							</tr>
+						</table>
 					</li>
 				}
 			</ul>
@@ -273,6 +375,23 @@
 		else
 		{
 			return "neuvedeno";
+		}
+	}
+
+	string FormatRemovedMeta(System.DateTimeOffset createdAt, System.DateTimeOffset? removedAt)
+	{
+		if (removedAt.HasValue)
+		{
+			var days = (int)(removedAt.Value - createdAt).TotalDays;
+			if (days < 0)
+			{
+				days = 0;
+			}
+			return $"Zrušeno {removedAt.Value:dd.MM.yyyy} · sledováno {GetPluralFormWithNumber(days, "den", "dny", "dní")}";
+		}
+		else
+		{
+			return $"sledováno od {createdAt:dd.MM.yyyy}";
 		}
 	}
 }


### PR DESCRIPTION
## Souhrn

Vizuální redesign obou e-mailových reportů (`ListingReport.cshtml` — nové nabídky + změny cen, `RemovedListingsReport.cshtml` — zrušené nabídky) se sjednoceným vizuálním jazykem, odlišeným jen akcentní barvou (modrá = nové, červená = zrušené). Mění se pouze šablony a testy, žádný C# kód.

## Změny

- **Spolehlivé vykreslení v Outlook mobile a Apple Mail** — řádek nabídky (obrázek + text) a hlavičky sekcí přešly z CSS gridu/flexboxu na tabulky (`role="presentation"`). Gradienty v hlavičkách nahradila plná akcentní barva (lépe přežívá nucenou inverzi barev v dark modu Outlooku) a přidána `color-scheme: light` meta, takže Apple Mail barvy neinvertuje.
- **Víc informací u nabídek** — titulek i lokalita zároveň; u změn cen barevný badge se šipkou, částkou a procentem (např. „↓ −200 000 Kč (−6,5 %)") plus přeškrtnutá původní cena; u zrušených řádek „Zrušeno … · sledováno X dní", badge „Již nedostupné" a zašedlý obrázek; název tasku/reportu v hlavičce.
- **Placeholder pro nabídky bez obrázku** (120×90 šedý blok) — řádky zůstávají zarovnané i při limitu 30 cid příloh.
- **Sdílený CSS blok** je v obou šablonách označen sentinel komentáři a test `Templates_SharedStylesAreInSync` hlídá, aby se kopie nerozjely.
- **Testy** — nový test pro `ListingReport` (dosud netestovaný), rozšířené asserty pro zrušené nabídky; oba render testy zapisují preview HTML do test output adresáře (`preview-*.html`) pro rychlou vizuální kontrolu v prohlížeči.

## Testování

- `dotnet test Infrastructure.Tests` — 3/3 testy prošly (render testy jsou zároveň kompilační brána šablon v RazorEngineCore).
- Vizuální kontrola preview HTML v prohlížeči.
- Po nasazení doporučuji poslat si report a zkontrolovat v Outlook mobile light + dark režimu (inverzi barev nelze ověřit jinak).