### PR TITLE
Fix: warningy v publish workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -22,14 +22,14 @@ jobs:
 
     steps:
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Retag ${{ inputs.source }} -> stable (no rebuild)
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       run: dotnet test -c Release --no-restore --verbosity normal
 
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
 
     - name: Docker metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ghcr.io/${{ github.repository }}
         # Every build goes to the test environment, plus an immutable per-commit tag.
@@ -44,10 +44,10 @@ jobs:
           type=sha,prefix=sha-,format=short
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and push image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile

--- a/Web.Client/Pages/ReportTasks/ReportTaskEditPage.razor.cs
+++ b/Web.Client/Pages/ReportTasks/ReportTaskEditPage.razor.cs
@@ -19,7 +19,8 @@ public partial class ReportTaskEditPage(
 	private bool isLoading;
 	private ReportTaskFormModel model = new();
 	private List<ScraperTaskOption> scraperTaskOptions = [];
-	private bool dummyCheckboxValue;
+	// Slouží jen jako ValueExpression pro HxCheckbox se scraper tasky; nikdy se do něj nezapisuje.
+	private bool dummyCheckboxValue = false;
 
 	protected override async Task OnInitializedAsync()
 	{


### PR DESCRIPTION
## Souhrn

Poslední běh publish workflow hlásil dva warningy — tento PR opravuje oba.

### 1. Deprecation Node.js 20 u docker akcí

Akce `docker/*` cílily na Node 20 a runner je vynuceně pouštěl na Node 24. Docker mezitím vydal nové major verze s nativní podporou Node 24, takže bumpuji v `publish.yml` i `promote.yml`:

| Akce | Před | Po |
|---|---|---|
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| docker/build-push-action | v6 | v7 |

Release notes všech čtyř majorů prošly — kromě přechodu na Node 24 odstranily jen deprecated inputy a env proměnné, které tato workflow nepoužívají.

### 2. Warning CS0649 v Web.Client

`ReportTaskEditPage.dummyCheckboxValue` se nikde nepřiřazuje (slouží jen jako `ValueExpression` pro `HxCheckbox` se scraper tasky). Přidána explicitní inicializace `= false` a vysvětlující komentář. Build Web.Client v Release nyní projde s 0 warningy.