### PR TITLE
Chore: aktualizace verzí GitHub Actions

### DIFF
--- a/.github/workflows/assign-pr-author.yml
+++ b/.github/workflows/assign-pr-author.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Assign PR author when no assignee exists
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,9 +20,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
     - name: Restore dependencies
@@ -33,7 +33,7 @@ jobs:
       run: dotnet test --no-build -c Release --verbosity normal --logger "trx" --collect:"XPlat Code Coverage" --results-directory ./TestResults
     - name: Upload test results
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-results
         path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
 


### PR DESCRIPTION
## Souhrn

Aktualizace zastaralých major verzí akcí ve workflow souborech:

| Akce | Původní | Nová | Soubory |
|---|---|---|---|
| actions/checkout | v5 | v7 | dotnet.yml, publish.yml |
| actions/setup-dotnet | v5 | v6 | dotnet.yml, publish.yml |
| actions/upload-artifact | v4 | v7 | dotnet.yml |
| actions/github-script | v8 | v9 | assign-pr-author.yml |

Docker akce (`docker/login-action@v4`, `docker/metadata-action@v6`, `docker/setup-buildx-action@v4`, `docker/build-push-action@v7`) jsou už na nejnovějších major verzích — `promote.yml` proto beze změny.

## Breaking changes

Prošel jsem release notes všech přeskočených major verzí — žádný breaking change se tohoto repa netýká. Nové verze znamenají hlavně přechod na Node.js 24 a ESM (vyžaduje runner ≥ 2.327.1, což GitHub-hosted `ubuntu-latest` splňuje). Skript v `assign-pr-author.yml` nepoužívá `require('@actions/github')` ani redeklaraci `getOctokit`, které github-script v9 rozbíjí.