### PR TITLE
Fix: chybějící registrace IHxMessageBoxService na serveru (HTTP 500)

### DIFF
--- a/Web.Api/DependencyInjection.cs
+++ b/Web.Api/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Threading.RateLimiting;
 using Havit.Blazor.Components.Web;
+using Havit.Blazor.Components.Web.Bootstrap;
 using Microsoft.AspNetCore.RateLimiting;
 using RealityScraper.Web.Api.Extensions;
 using RealityScraper.Web.Api.Infrastructure;
@@ -65,6 +66,7 @@ public static class DependencyInjection
 
 		services.AddHxServices();
 		services.AddHxMessenger();
+		services.AddHxMessageBoxHost();
 
 		return services;
 	}


### PR DESCRIPTION
## Problém
Frontend padal s HTTP 500 při statickém server-side renderování (např. stránka `/not-found`):

```
System.InvalidOperationException: Cannot provide a value for property 'MessageBoxService' on type 'Havit.Blazor.Components.Web.Bootstrap.HxMessageBoxHost'. There is no registered service of type 'Havit.Blazor.Components.Web.Bootstrap.IHxMessageBoxService'.
```

## Příčina
`MainLayout.razor` obsahuje `<HxMessageBoxHost />`, který si přes property injection vyžaduje `IHxMessageBoxService`. Layout se renderuje i na serveru (statické SSR / prerendering), ale registrace `AddHxMessageBoxHost()` byla jen ve WASM klientovi (`Web.Client/Program.cs`) — serverový DI kontejner službu neznal.

## Oprava
Do `Web.Api/DependencyInjection.cs` přidána registrace `services.AddHxMessageBoxHost()` vedle stávajících Havit registrací, včetně potřebného `using Havit.Blazor.Components.Web.Bootstrap;`.