### PR TITLE
Fix: větší snímek nemovitosti v e-mailových reportech (160×120 px)

### DIFF
--- a/Infrastructure/Utilities/Mailing/Templates/ListingReport.cshtml
+++ b/Infrastructure/Utilities/Mailing/Templates/ListingReport.cshtml
@@ -143,8 +143,8 @@
 		}
 
 		.property-image {
-			width: 120px;
-			height: 90px;
+			width: 160px;
+			height: 120px;
 			object-fit: cover;
 			border-radius: 8px;
 			display: block;
@@ -152,14 +152,14 @@
 		}
 
 		.property-image-placeholder {
-			width: 120px;
-			height: 90px;
+			width: 160px;
+			height: 120px;
 			border-radius: 8px;
 			background-color: #e5e7eb;
 			color: #9ca3af;
-			font-size: 30px;
+			font-size: 40px;
 			text-align: center;
-			line-height: 90px;
+			line-height: 120px;
 		}
 
 		.property-title {
@@ -318,7 +318,7 @@
 						<li class="property-item">
 							<table role="presentation" class="property-row" width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="property-image-cell" width="136" valign="top">
+									<td class="property-image-cell" width="176" valign="top">
 										@if (!string.IsNullOrEmpty(listing.ImageUrl))
 										{
 											<img src="@SafeUrl(listing.ImageUrl)" alt="@E(listing.Location)" class="property-image">
@@ -360,7 +360,7 @@
 						<li class="property-item">
 							<table role="presentation" class="property-row" width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="property-image-cell" width="136" valign="top">
+									<td class="property-image-cell" width="176" valign="top">
 										@if (!string.IsNullOrEmpty(listing.ImageUrl))
 										{
 											<img src="@SafeUrl(listing.ImageUrl)" alt="@E(listing.Location)" class="property-image">

--- a/Infrastructure/Utilities/Mailing/Templates/RemovedListingsReport.cshtml
+++ b/Infrastructure/Utilities/Mailing/Templates/RemovedListingsReport.cshtml
@@ -143,8 +143,8 @@
 		}
 
 		.property-image {
-			width: 120px;
-			height: 90px;
+			width: 160px;
+			height: 120px;
 			object-fit: cover;
 			border-radius: 8px;
 			display: block;
@@ -152,14 +152,14 @@
 		}
 
 		.property-image-placeholder {
-			width: 120px;
-			height: 90px;
+			width: 160px;
+			height: 120px;
 			border-radius: 8px;
 			background-color: #e5e7eb;
 			color: #9ca3af;
-			font-size: 30px;
+			font-size: 40px;
 			text-align: center;
-			line-height: 90px;
+			line-height: 120px;
 		}
 
 		.property-title {
@@ -299,7 +299,7 @@
 					<li class="property-item">
 						<table role="presentation" class="property-row" width="100%" cellpadding="0" cellspacing="0">
 							<tr>
-								<td class="property-image-cell" width="136" valign="top">
+								<td class="property-image-cell" width="176" valign="top">
 									@if (listing.HasImage)
 									{
 										<img src="cid:@listing.ListingId" alt="@E(listing.Location)" class="property-image">


### PR DESCRIPTION
## Souhrn

Redesign e-mailových reportů v #83 zmenšil snímek nemovitosti ze 160×120 px na 120×90 px. Snímek je přitom hlavní prvek, podle kterého se příjemce v mailu orientuje — tento PR vrací větší velikost z původní varianty.

## Změny

- `.property-image` a `.property-image-placeholder` zvětšeny ze 120×90 px na 160×120 px v obou šablonách (`ListingReport.cshtml`, `RemovedListingsReport.cshtml`); u placeholderu úměrně upraven `line-height` (120 px) a velikost emoji (40 px).
- Šířka obrázkové buňky tabulky změněna z `width="136"` na `width="176"` (160 px obrázek + 16 px odsazení).
- Sdílený CSS blok obou šablon zůstává identický (hlídá test `Templates_SharedStylesAreInSync`).

Kešované obrázky (cid přílohy) se ukládají v původním rozlišení, takže větší zobrazení nevyžaduje žádnou změnu na serveru.

## Testování

- `dotnet test Infrastructure.Tests --filter FullyQualifiedName~RazorEmailGenerator` — 3/3 testy prošly (render testy obou šablon + synchronizace sdílených stylů).
- Vizuální kontrola vygenerovaných náhledů `preview-ListingReport.html` a `preview-RemovedListingsReport.html`.