### PR TITLE
Feat: stránka Reality – seznam inzerátů s filtrováním a historií cen

### DIFF
--- a/Application.Tests/Features/Listings/GetListingsQueryHandlerTests.cs
+++ b/Application.Tests/Features/Listings/GetListingsQueryHandlerTests.cs
@@ -1,0 +1,120 @@
+using Moq;
+using RealityScraper.Application.Features.Listings.GetList;
+using RealityScraper.Application.Interfaces.Repositories.Configuration;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.Domain.Entities.Realty;
+using RealityScraper.Domain.Entities.Tasks;
+
+namespace RealityScraper.Application.Tests.Features.Listings;
+
+public class GetListingsQueryHandlerTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+	private readonly Mock<IListingRepository> listingRepositoryMock = new();
+	private readonly Mock<IScraperTaskRepository> scraperTaskRepositoryMock = new();
+
+	private GetListingsQueryHandler CreateSut()
+	{
+		return new GetListingsQueryHandler(listingRepositoryMock.Object, scraperTaskRepositoryMock.Object);
+	}
+
+	private static Listing CreateListing(Guid? scraperTaskId = null)
+	{
+		return new Listing
+		{
+			Id = Guid.NewGuid(),
+			ExternalId = "ext-1",
+			Title = "Prodej domu",
+			Location = "Brno",
+			Url = "https://example.com/1",
+			ImageUrl = string.Empty,
+			CreatedAt = Now,
+			LastSeenAt = Now,
+			ScraperTaskId = scraperTaskId
+		};
+	}
+
+	private void SetupRepositories(List<Listing> listings, int totalCount, List<ScraperTask>? tasks = null)
+	{
+		listingRepositoryMock
+			.Setup(x => x.GetPagedAsync(It.IsAny<bool?>(), It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((listings, totalCount));
+
+		scraperTaskRepositoryMock
+			.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(tasks ?? []);
+	}
+
+	[Fact]
+	public async Task Handle_PassesFiltersAndPagingToRepository()
+	{
+		// Arrange
+		var taskId = Guid.NewGuid();
+		SetupRepositories([], 0);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetListingsQuery(true, taskId, "dům", 2, 20), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		listingRepositoryMock.Verify(x => x.GetPagedAsync(true, taskId, "dům", 40, 20, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Theory]
+	[InlineData(-5, 0, 0, 1)]
+	[InlineData(0, 500, 0, 100)]
+	[InlineData(3, 1000, 300, 100)]
+	public async Task Handle_ClampsPageIndexAndPageSize(int pageIndex, int pageSize, int expectedSkip, int expectedTake)
+	{
+		// Arrange
+		SetupRepositories([], 0);
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(new GetListingsQuery(null, null, null, pageIndex, pageSize), CancellationToken.None);
+
+		// Assert
+		listingRepositoryMock.Verify(x => x.GetPagedAsync(null, null, null, expectedSkip, expectedTake, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_MapsScraperTaskName()
+	{
+		// Arrange
+		var task = new ScraperTask("Můj task", "0 * * * *", true, Now, null)
+		{
+			Id = Guid.NewGuid()
+		};
+		var listingWithTask = CreateListing(task.Id);
+		var listingWithoutTask = CreateListing();
+		SetupRepositories([listingWithTask, listingWithoutTask], 2, [task]);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetListingsQuery(null, null, null, 0, 15), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(2, result.Value.TotalCount);
+		Assert.Equal("Můj task", result.Value.Items[0].ScraperTaskName);
+		Assert.Null(result.Value.Items[1].ScraperTaskName);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsTotalCountFromRepository()
+	{
+		// Arrange
+		SetupRepositories([CreateListing()], 123);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetListingsQuery(null, null, null, 0, 15), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Single(result.Value.Items);
+		Assert.Equal(123, result.Value.TotalCount);
+	}
+}

--- a/Application/Features/Listings/GetList/GetListingsQuery.cs
+++ b/Application/Features/Listings/GetList/GetListingsQuery.cs
@@ -1,0 +1,5 @@
+using RealityScraper.Application.Abstractions.Messaging;
+
+namespace RealityScraper.Application.Features.Listings.GetList;
+
+public record GetListingsQuery(bool? IsActive, Guid? ScraperTaskId, string? SearchTerm, int PageIndex, int PageSize) : IQuery<ListingPageDto>;

--- a/Application/Features/Listings/GetList/GetListingsQueryHandler.cs
+++ b/Application/Features/Listings/GetList/GetListingsQueryHandler.cs
@@ -1,0 +1,49 @@
+using RealityScraper.Application.Abstractions.Messaging;
+using RealityScraper.Application.Interfaces.Repositories.Configuration;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Features.Listings.GetList;
+
+internal sealed class GetListingsQueryHandler : IQueryHandler<GetListingsQuery, ListingPageDto>
+{
+	private const int MaxPageSize = 100;
+
+	private readonly IListingRepository listingRepository;
+	private readonly IScraperTaskRepository scraperTaskRepository;
+
+	public GetListingsQueryHandler(IListingRepository listingRepository, IScraperTaskRepository scraperTaskRepository)
+	{
+		this.listingRepository = listingRepository;
+		this.scraperTaskRepository = scraperTaskRepository;
+	}
+
+	public async Task<Result<ListingPageDto>> Handle(GetListingsQuery query, CancellationToken cancellationToken)
+	{
+		var pageIndex = Math.Max(query.PageIndex, 0);
+		var pageSize = Math.Clamp(query.PageSize, 1, MaxPageSize);
+
+		var (listings, totalCount) = await listingRepository.GetPagedAsync(
+			query.IsActive,
+			query.ScraperTaskId,
+			query.SearchTerm,
+			pageIndex * pageSize,
+			pageSize,
+			cancellationToken);
+
+		var scraperTasks = await scraperTaskRepository.GetAllAsync(cancellationToken);
+		var taskNamesById = scraperTasks.ToDictionary(t => t.Id, t => t.Name);
+
+		var result = new ListingPageDto
+		{
+			Items = listings
+				.Select(l => ListingMapper.MapToDto(
+					l,
+					l.ScraperTaskId.HasValue && taskNamesById.TryGetValue(l.ScraperTaskId.Value, out var name) ? name : null))
+				.ToList(),
+			TotalCount = totalCount
+		};
+
+		return Result.Success(result);
+	}
+}

--- a/Application/Features/Listings/GetPriceHistory/GetListingPriceHistoryQuery.cs
+++ b/Application/Features/Listings/GetPriceHistory/GetListingPriceHistoryQuery.cs
@@ -1,0 +1,5 @@
+using RealityScraper.Application.Abstractions.Messaging;
+
+namespace RealityScraper.Application.Features.Listings.GetPriceHistory;
+
+public record GetListingPriceHistoryQuery(Guid ListingId) : IQuery<List<PriceHistoryDto>>;

--- a/Application/Features/Listings/GetPriceHistory/GetListingPriceHistoryQueryHandler.cs
+++ b/Application/Features/Listings/GetPriceHistory/GetListingPriceHistoryQueryHandler.cs
@@ -1,0 +1,31 @@
+using RealityScraper.Application.Abstractions.Messaging;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Features.Listings.GetPriceHistory;
+
+internal sealed class GetListingPriceHistoryQueryHandler : IQueryHandler<GetListingPriceHistoryQuery, List<PriceHistoryDto>>
+{
+	private readonly IListingRepository listingRepository;
+
+	public GetListingPriceHistoryQueryHandler(IListingRepository listingRepository)
+	{
+		this.listingRepository = listingRepository;
+	}
+
+	public async Task<Result<List<PriceHistoryDto>>> Handle(GetListingPriceHistoryQuery query, CancellationToken cancellationToken)
+	{
+		var listing = await listingRepository.GetWithPriceHistoryAsync(query.ListingId, cancellationToken);
+		if (listing == null)
+		{
+			return Result.Failure<List<PriceHistoryDto>>(Error.NotFound("Listing.NotFound", $"Listing with ID {query.ListingId} was not found."));
+		}
+
+		var result = listing.PriceHistories
+			.OrderBy(h => h.RecordedAt)
+			.Select(ListingMapper.MapToPriceHistoryDto)
+			.ToList();
+
+		return Result.Success(result);
+	}
+}

--- a/Application/Features/Listings/ListingDto.cs
+++ b/Application/Features/Listings/ListingDto.cs
@@ -1,0 +1,26 @@
+namespace RealityScraper.Application.Features.Listings;
+
+public class ListingDto
+{
+	public Guid Id { get; set; }
+
+	public string Title { get; set; } = null!;
+
+	public string Location { get; set; } = null!;
+
+	public decimal? Price { get; set; }
+
+	public string Url { get; set; } = null!;
+
+	public string ImageUrl { get; set; } = null!;
+
+	public DateTimeOffset CreatedAt { get; set; }
+
+	public DateTimeOffset LastSeenAt { get; set; }
+
+	public DateTimeOffset? RemovedAt { get; set; }
+
+	public Guid? ScraperTaskId { get; set; }
+
+	public string? ScraperTaskName { get; set; }
+}

--- a/Application/Features/Listings/ListingMapper.cs
+++ b/Application/Features/Listings/ListingMapper.cs
@@ -1,0 +1,33 @@
+using RealityScraper.Domain.Entities.Realty;
+
+namespace RealityScraper.Application.Features.Listings;
+
+internal static class ListingMapper
+{
+	public static ListingDto MapToDto(Listing entity, string? scraperTaskName)
+	{
+		return new ListingDto
+		{
+			Id = entity.Id,
+			Title = entity.Title,
+			Location = entity.Location,
+			Price = entity.Price,
+			Url = entity.Url,
+			ImageUrl = entity.ImageUrl,
+			CreatedAt = entity.CreatedAt,
+			LastSeenAt = entity.LastSeenAt,
+			RemovedAt = entity.RemovedAt,
+			ScraperTaskId = entity.ScraperTaskId,
+			ScraperTaskName = scraperTaskName
+		};
+	}
+
+	public static PriceHistoryDto MapToPriceHistoryDto(PriceHistory entity)
+	{
+		return new PriceHistoryDto
+		{
+			Price = entity.Price,
+			RecordedAt = entity.RecordedAt
+		};
+	}
+}

--- a/Application/Features/Listings/ListingPageDto.cs
+++ b/Application/Features/Listings/ListingPageDto.cs
@@ -1,0 +1,8 @@
+namespace RealityScraper.Application.Features.Listings;
+
+public class ListingPageDto
+{
+	public List<ListingDto> Items { get; set; } = [];
+
+	public int TotalCount { get; set; }
+}

--- a/Application/Features/Listings/PriceHistoryDto.cs
+++ b/Application/Features/Listings/PriceHistoryDto.cs
@@ -1,0 +1,8 @@
+namespace RealityScraper.Application.Features.Listings;
+
+public class PriceHistoryDto
+{
+	public decimal? Price { get; set; }
+
+	public DateTimeOffset RecordedAt { get; set; }
+}

--- a/Application/Interfaces/Repositories/Realty/IListingRepository.cs
+++ b/Application/Interfaces/Repositories/Realty/IListingRepository.cs
@@ -11,4 +11,8 @@ public interface IListingRepository
 	Task<List<Listing>> GetByScraperTaskIdAsync(Guid scraperTaskId, CancellationToken cancellationToken);
 
 	Task<List<Listing>> GetRemovedInPeriodAsync(Guid scraperTaskId, DateTimeOffset fromExclusive, DateTimeOffset toInclusive, CancellationToken cancellationToken);
+
+	Task<(List<Listing> Items, int TotalCount)> GetPagedAsync(bool? isActive, Guid? scraperTaskId, string? searchTerm, int skip, int take, CancellationToken cancellationToken);
+
+	Task<Listing?> GetWithPriceHistoryAsync(Guid id, CancellationToken cancellationToken);
 }

--- a/Infrastructure/Repositories/Realty/ListingRepository.cs
+++ b/Infrastructure/Repositories/Realty/ListingRepository.cs
@@ -27,6 +27,62 @@ internal class ListingRepository : Repository<Listing>, IListingRepository
 			.ToListAsync(cancellationToken);
 	}
 
+	public async Task<(List<Listing> Items, int TotalCount)> GetPagedAsync(bool? isActive, Guid? scraperTaskId, string? searchTerm, int skip, int take, CancellationToken cancellationToken)
+	{
+		var query = dbContext
+			.Set<Listing>()
+			.AsNoTracking()
+			.AsQueryable();
+
+		if (isActive == true)
+		{
+			query = query.Where(x => x.RemovedAt == null);
+		}
+		else if (isActive == false)
+		{
+			query = query.Where(x => x.RemovedAt != null);
+		}
+
+		if (scraperTaskId.HasValue)
+		{
+			query = query.Where(x => x.ScraperTaskId == scraperTaskId.Value);
+		}
+
+		if (!string.IsNullOrWhiteSpace(searchTerm))
+		{
+			var pattern = $"%{EscapeLikePattern(searchTerm.Trim())}%";
+			query = query.Where(x => EF.Functions.ILike(x.Title, pattern) || EF.Functions.ILike(x.Location, pattern));
+		}
+
+		var totalCount = await query.CountAsync(cancellationToken);
+
+		var items = await query
+			.OrderByDescending(x => x.CreatedAt)
+			.ThenBy(x => x.Id)
+			.Skip(skip)
+			.Take(take)
+			.ToListAsync(cancellationToken);
+
+		return (items, totalCount);
+	}
+
+	public Task<Listing?> GetWithPriceHistoryAsync(Guid id, CancellationToken cancellationToken)
+	{
+		return dbContext
+			.Set<Listing>()
+			.AsNoTracking()
+			.Include(x => x.PriceHistories)
+			.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+	}
+
+	private static string EscapeLikePattern(string value)
+	{
+		return value
+			.Replace(@"\", @"\\")
+			.Replace("%", @"\%")
+			.Replace("_", @"\_");
+	}
+
 	public Task<List<Listing>> GetRemovedInPeriodAsync(Guid scraperTaskId, DateTimeOffset fromExclusive, DateTimeOffset toInclusive, CancellationToken cancellationToken)
 	{
 		return dbContext

--- a/Web.Api/Endpoints/Listings/GetListingPriceHistoryEndpoint.cs
+++ b/Web.Api/Endpoints/Listings/GetListingPriceHistoryEndpoint.cs
@@ -1,0 +1,27 @@
+using RealityScraper.Application.Abstractions.Messaging;
+using RealityScraper.Application.Features.Listings;
+using RealityScraper.Application.Features.Listings.GetPriceHistory;
+using RealityScraper.Web.Api.Infrastructure;
+using RealityScraper.Web.Api.Mappers.Listings;
+
+namespace RealityScraper.Web.Api.Endpoints.Listings;
+
+internal sealed class GetListingPriceHistoryEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapGet("/api/listings/{id:guid}/price-history", async (
+			Guid id,
+			IQueryHandler<GetListingPriceHistoryQuery, List<PriceHistoryDto>> queryHandler,
+			CancellationToken cancellationToken) =>
+		{
+			var query = new GetListingPriceHistoryQuery(id);
+
+			var result = await queryHandler.Handle(query, cancellationToken);
+
+			return result.IsSuccess
+				? Results.Ok(result.Value.Select(ListingDtoMapper.MapToResult).ToList())
+				: CustomResults.Problem(result);
+		});
+	}
+}

--- a/Web.Api/Endpoints/Listings/GetListingsEndpoint.cs
+++ b/Web.Api/Endpoints/Listings/GetListingsEndpoint.cs
@@ -1,0 +1,31 @@
+using RealityScraper.Application.Abstractions.Messaging;
+using RealityScraper.Application.Features.Listings;
+using RealityScraper.Application.Features.Listings.GetList;
+using RealityScraper.Web.Api.Infrastructure;
+using RealityScraper.Web.Api.Mappers.Listings;
+
+namespace RealityScraper.Web.Api.Endpoints.Listings;
+
+internal sealed class GetListingsEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapGet("/api/listings", async (
+			IQueryHandler<GetListingsQuery, ListingPageDto> queryHandler,
+			CancellationToken cancellationToken,
+			bool? isActive,
+			Guid? scraperTaskId,
+			string? search,
+			int pageIndex = 0,
+			int pageSize = 15) =>
+		{
+			var query = new GetListingsQuery(isActive, scraperTaskId, search, pageIndex, pageSize);
+
+			var result = await queryHandler.Handle(query, cancellationToken);
+
+			return result.IsSuccess
+				? Results.Ok(ListingDtoMapper.MapToResult(result.Value))
+				: CustomResults.Problem(result);
+		});
+	}
+}

--- a/Web.Api/Mappers/Listings/ListingDtoMapper.cs
+++ b/Web.Api/Mappers/Listings/ListingDtoMapper.cs
@@ -1,0 +1,43 @@
+using RealityScraper.Application.Features.Listings;
+using RealityScraper.Web.Shared.Models.Listings;
+
+namespace RealityScraper.Web.Api.Mappers.Listings;
+
+public static class ListingDtoMapper
+{
+	public static ListingPageResult MapToResult(ListingPageDto dto)
+	{
+		return new ListingPageResult
+		{
+			Items = dto.Items.Select(MapToResult).ToList(),
+			TotalCount = dto.TotalCount
+		};
+	}
+
+	public static ListingResult MapToResult(ListingDto dto)
+	{
+		return new ListingResult
+		{
+			Id = dto.Id,
+			Title = dto.Title,
+			Location = dto.Location,
+			Price = dto.Price,
+			Url = dto.Url,
+			ImageUrl = dto.ImageUrl,
+			CreatedAt = dto.CreatedAt,
+			LastSeenAt = dto.LastSeenAt,
+			RemovedAt = dto.RemovedAt,
+			ScraperTaskId = dto.ScraperTaskId,
+			ScraperTaskName = dto.ScraperTaskName
+		};
+	}
+
+	public static PriceHistoryResult MapToResult(PriceHistoryDto dto)
+	{
+		return new PriceHistoryResult
+		{
+			Price = dto.Price,
+			RecordedAt = dto.RecordedAt
+		};
+	}
+}

--- a/Web.Client/Layout/NavMenu.razor
+++ b/Web.Client/Layout/NavMenu.razor
@@ -29,6 +29,12 @@
                     <span class="bi bi-clipboard-check-nav-menu" aria-hidden="true"></span><span class="nav-text">Reporty</span>
                 </NavLink>
             </div>
+
+            <div class="nav-item" data-tooltip="Reality">
+                <NavLink class="nav-link" href="listings" title="Reality">
+                    <span class="bi bi-tags-nav-menu" aria-hidden="true"></span><span class="nav-text">Reality</span>
+                </NavLink>
+            </div>
         </nav>
     </div>
 </div>

--- a/Web.Client/Pages/Listings/ListingListPage.razor
+++ b/Web.Client/Pages/Listings/ListingListPage.razor
@@ -1,0 +1,116 @@
+@page "/listings"
+<PageTitle>Reality</PageTitle>
+
+<h3>Reality</h3>
+
+<div class="row g-2 mb-3">
+    <div class="col-12 col-md-3">
+        <HxSelect TItem="StateFilterOption" TValue="bool?"
+                  @bind-Value="activeFilter"
+                  @bind-Value:after="RefreshGridAsync"
+                  Label="Stav"
+                  Data="stateFilterOptions"
+                  TextSelector="o => o.Name"
+                  ValueSelector="o => (bool?)o.Value"
+                  NullText="Vše"
+                  Nullable="true" />
+    </div>
+    <div class="col-12 col-md-4">
+        <HxSelect TItem="ScraperTaskResult" TValue="Guid?"
+                  @bind-Value="scraperTaskFilter"
+                  @bind-Value:after="RefreshGridAsync"
+                  Label="Scraper task"
+                  Data="scraperTasks"
+                  TextSelector="t => t.Name"
+                  ValueSelector="t => (Guid?)t.Id"
+                  NullText="Všechny tasky"
+                  Nullable="true" />
+    </div>
+    <div class="col-12 col-md-5">
+        <HxInputText @bind-Value="searchTerm"
+                     @bind-Value:after="RefreshGridAsync"
+                     Label="Hledat"
+                     Placeholder="Název nebo lokalita..." />
+    </div>
+</div>
+
+<HxGrid @ref="grid" TItem="ListingResult" DataProvider="LoadData" Responsive="true">
+    <Columns>
+        <HxGridColumn HeaderText="Náhled">
+            <ItemTemplate Context="listing">
+                @if (!string.IsNullOrEmpty(listing.ImageUrl))
+                {
+                    <img src="@listing.ImageUrl" alt="@listing.Title" width="80" height="60" loading="lazy" style="object-fit: cover; border-radius: 4px;" />
+                }
+            </ItemTemplate>
+        </HxGridColumn>
+        <HxGridColumn HeaderText="Název">
+            <ItemTemplate Context="listing">
+                <a href="@listing.Url" target="_blank" rel="noopener">@listing.Title</a>
+            </ItemTemplate>
+        </HxGridColumn>
+        <HxGridColumn HeaderText="Lokalita" ItemTextSelector="l => l.Location" />
+        <HxGridColumn HeaderText="Cena">
+            <ItemTemplate Context="listing">
+                @FormatPrice(listing.Price)
+            </ItemTemplate>
+        </HxGridColumn>
+        <HxGridColumn HeaderText="Task" ItemTextSelector="l => l.ScraperTaskName" />
+        <HxGridColumn HeaderText="Nalezeno">
+            <ItemTemplate Context="listing">
+                @TimeZoneHelper.FormatLocal(listing.CreatedAt)
+            </ItemTemplate>
+        </HxGridColumn>
+        <HxGridColumn HeaderText="Naposledy viděno">
+            <ItemTemplate Context="listing">
+                @TimeZoneHelper.FormatLocal(listing.LastSeenAt)
+            </ItemTemplate>
+        </HxGridColumn>
+        <HxGridColumn HeaderText="Stav">
+            <ItemTemplate Context="listing">
+                @if (listing.RemovedAt == null)
+                {
+                    <HxBadge Color="ThemeColor.Success">Aktivní</HxBadge>
+                }
+                else
+                {
+                    <HxBadge Color="ThemeColor.Secondary" Tooltip="@($"Odstraněno {TimeZoneHelper.FormatLocal(listing.RemovedAt)}")">Odstraněno</HxBadge>
+                }
+            </ItemTemplate>
+        </HxGridColumn>
+        <HxGridColumn HeaderText="Akce">
+            <ItemTemplate Context="listing">
+                <HxButton Icon="BootstrapIcon.GraphUp" Color="ThemeColor.Info" Size="ButtonSize.Small" Outline="true" Tooltip="Historie cen" OnClick="() => HandleShowPriceHistoryClick(listing)" />
+            </ItemTemplate>
+        </HxGridColumn>
+    </Columns>
+</HxGrid>
+
+<HxOffcanvas @ref="priceHistoryOffcanvas" Title="@priceHistoryOffcanvasTitle">
+    <BodyTemplate>
+        @if (selectedPriceHistory == null || selectedPriceHistory.Count == 0)
+        {
+            <p class="text-muted">Žádná historie cen není k dispozici.</p>
+        }
+        else
+        {
+            <table class="table table-sm">
+                <thead>
+                    <tr>
+                        <th>Datum</th>
+                        <th class="text-end">Cena</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var record in selectedPriceHistory)
+                    {
+                        <tr>
+                            <td>@TimeZoneHelper.FormatLocal(record.RecordedAt)</td>
+                            <td class="text-end">@FormatPrice(record.Price)</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </BodyTemplate>
+</HxOffcanvas>

--- a/Web.Client/Pages/Listings/ListingListPage.razor.cs
+++ b/Web.Client/Pages/Listings/ListingListPage.razor.cs
@@ -1,0 +1,116 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Havit.Blazor.Components.Web;
+using Havit.Blazor.Components.Web.Bootstrap;
+using RealityScraper.Web.Shared.Models.Listings;
+using RealityScraper.Web.Shared.Models.ScraperTasks;
+
+namespace RealityScraper.Web.Client.Pages.Listings;
+
+public partial class ListingListPage(
+	HttpClient http,
+	IHxMessengerService messenger)
+{
+	private const int DefaultPageSize = 15;
+
+	private static readonly CultureInfo czechCulture = CultureInfo.GetCultureInfo("cs-CZ");
+
+	private static readonly List<StateFilterOption> stateFilterOptions =
+	[
+		new(true, "Aktivní"),
+		new(false, "Neaktivní")
+	];
+
+	private HxGrid<ListingResult> grid = null!;
+	private HxOffcanvas priceHistoryOffcanvas = null!;
+	private List<ScraperTaskResult> scraperTasks = [];
+	private bool? activeFilter = true;
+	private Guid? scraperTaskFilter;
+	private string? searchTerm;
+	private List<PriceHistoryResult>? selectedPriceHistory;
+	private string priceHistoryOffcanvasTitle = "Historie cen";
+
+	protected override async Task OnInitializedAsync()
+	{
+		try
+		{
+			scraperTasks = await http.GetFromJsonAsync<List<ScraperTaskResult>>("/api/scraper-tasks") ?? [];
+		}
+		catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+		{
+			messenger.AddError("Nepodařilo se načíst seznam tasků pro filtr.");
+		}
+	}
+
+	private async Task<GridDataProviderResult<ListingResult>> LoadData(GridDataProviderRequest<ListingResult> request)
+	{
+		try
+		{
+			var pageSize = request.Count ?? DefaultPageSize;
+			var pageIndex = request.StartIndex / pageSize;
+
+			var url = $"/api/listings?pageIndex={pageIndex}&pageSize={pageSize}";
+			if (activeFilter.HasValue)
+			{
+				url += $"&isActive={(activeFilter.Value ? "true" : "false")}";
+			}
+
+			if (scraperTaskFilter.HasValue)
+			{
+				url += $"&scraperTaskId={scraperTaskFilter.Value}";
+			}
+
+			if (!string.IsNullOrWhiteSpace(searchTerm))
+			{
+				url += $"&search={Uri.EscapeDataString(searchTerm.Trim())}";
+			}
+
+			var page = await http.GetFromJsonAsync<ListingPageResult>(url, request.CancellationToken)
+				?? new ListingPageResult();
+
+			return new GridDataProviderResult<ListingResult>
+			{
+				Data = page.Items,
+				TotalCount = page.TotalCount
+			};
+		}
+		catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+		{
+			messenger.AddError("Nepodařilo se načíst seznam realit.");
+			return new GridDataProviderResult<ListingResult>
+			{
+				Data = [],
+				TotalCount = 0
+			};
+		}
+	}
+
+	private async Task RefreshGridAsync()
+	{
+		await grid.RefreshDataAsync(GridStateResetOptions.ResetPosition);
+	}
+
+	private async Task HandleShowPriceHistoryClick(ListingResult listing)
+	{
+		try
+		{
+			selectedPriceHistory = await http.GetFromJsonAsync<List<PriceHistoryResult>>($"/api/listings/{listing.Id}/price-history");
+			priceHistoryOffcanvasTitle = $"Historie cen – {listing.Title}";
+			await priceHistoryOffcanvas.ShowAsync();
+		}
+		catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+		{
+			messenger.AddError("Nepodařilo se načíst historii cen.");
+		}
+	}
+
+	private static string FormatPrice(decimal? price)
+	{
+		return price.HasValue
+			? string.Create(czechCulture, $"{price.Value:N0} Kč")
+			: "—";
+	}
+
+	private record StateFilterOption(bool Value, string Name);
+}

--- a/Web.Client/_Imports.razor
+++ b/Web.Client/_Imports.razor
@@ -17,4 +17,5 @@
 @using RealityScraper.Web.Shared.Models.ScraperTaskRecipients
 @using RealityScraper.Web.Shared.Models.ScraperTaskTargets
 @using RealityScraper.Web.Shared.Models.ReportTasks
+@using RealityScraper.Web.Shared.Models.Listings
 @using Blazilla

--- a/Web.Shared/Models/Listings/ListingPageResult.cs
+++ b/Web.Shared/Models/Listings/ListingPageResult.cs
@@ -1,0 +1,8 @@
+namespace RealityScraper.Web.Shared.Models.Listings;
+
+public class ListingPageResult
+{
+	public List<ListingResult> Items { get; set; } = [];
+
+	public int TotalCount { get; set; }
+}

--- a/Web.Shared/Models/Listings/ListingResult.cs
+++ b/Web.Shared/Models/Listings/ListingResult.cs
@@ -1,0 +1,26 @@
+namespace RealityScraper.Web.Shared.Models.Listings;
+
+public class ListingResult
+{
+	public Guid Id { get; set; }
+
+	public string Title { get; set; } = null!;
+
+	public string Location { get; set; } = null!;
+
+	public decimal? Price { get; set; }
+
+	public string Url { get; set; } = null!;
+
+	public string ImageUrl { get; set; } = null!;
+
+	public DateTimeOffset CreatedAt { get; set; }
+
+	public DateTimeOffset LastSeenAt { get; set; }
+
+	public DateTimeOffset? RemovedAt { get; set; }
+
+	public Guid? ScraperTaskId { get; set; }
+
+	public string? ScraperTaskName { get; set; }
+}

--- a/Web.Shared/Models/Listings/PriceHistoryResult.cs
+++ b/Web.Shared/Models/Listings/PriceHistoryResult.cs
@@ -1,0 +1,8 @@
+namespace RealityScraper.Web.Shared.Models.Listings;
+
+public class PriceHistoryResult
+{
+	public decimal? Price { get; set; }
+
+	public DateTimeOffset RecordedAt { get; set; }
+}


### PR DESCRIPTION
## Co PR přidává

Nová Blazor stránka **Reality** (`/listings`) — seznam sesbíraných inzerátů s filtrováním a detailem s historií cen. Položka „Reality" přibyla v navigačním menu.

### UI (Web.Client)

- HxGrid se **serverovým stránkováním** — na rozdíl od stávajících stránek se nenačítá vše najednou, inzerátů můžou být tisíce.
- Filtry: stav (Aktivní — výchozí / Neaktivní / Vše), scraper task, fulltext v názvu a lokalitě. Změna filtru resetuje grid na první stránku (`GridStateResetOptions.ResetPosition`).
- Sloupce: náhled (80×60 px, lazy loading), název s odkazem na původní inzerát, lokalita, cena, task, nalezeno, naposledy viděno, stav (badge s datem odstranění v tooltipu).
- Offcanvas s historií cen inzerátu (tabulka datum + cena).

### API a aplikační vrstva

- `GET /api/listings` — filtry + stránkování (pageIndex/pageSize, pageSize omezen na 100), vrací `ListingPageResult` (items + totalCount).
- `GET /api/listings/{id}/price-history` — historie cen, 404 pro neexistující inzerát.
- Nové query handlery `GetListingsQueryHandler` a `GetListingPriceHistoryQueryHandler` podle stávajícího CQRS vzoru; aktivní inzerát = `RemovedAt == null`.
- `ListingRepository.GetPagedAsync` — fulltext přes `ILIKE` (case-insensitive) s escapováním `%`/`_`/`\`, řazení od nejnovějších, využívá existující index `{ScraperTaskId, RemovedAt}`. Bez DB migrace.

### Testy a ověření

- 6 nových unit testů `GetListingsQueryHandler` (předání filtrů, clamp stránkování, mapování názvu tasku, totalCount); celá solution 110/110 zeleně.
- Ověřeno E2E přes Playwright proti lokálnímu Postgresu se seed daty: filtry, kombinace filtrů, fulltext (case-insensitivita, literál `%`), stránkování, reset stránky při změně filtru, offcanvas s historií cen, 404 na neexistující ID.
