### PR TITLE
Feat: kompletní historie cen v draweru vč. aktuální ceny a rozdílů

### DIFF
--- a/Application.Tests/Features/Listings/GetListingPriceHistoryQueryHandlerTests.cs
+++ b/Application.Tests/Features/Listings/GetListingPriceHistoryQueryHandlerTests.cs
@@ -1,0 +1,99 @@
+using Moq;
+using RealityScraper.Application.Features.Listings.GetPriceHistory;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.Domain.Entities.Realty;
+
+namespace RealityScraper.Application.Tests.Features.Listings;
+
+public class GetListingPriceHistoryQueryHandlerTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+	private readonly Mock<IListingRepository> listingRepositoryMock = new();
+
+	private GetListingPriceHistoryQueryHandler CreateSut()
+	{
+		return new GetListingPriceHistoryQueryHandler(listingRepositoryMock.Object);
+	}
+
+	private static Listing CreateListing(decimal? price, DateTimeOffset priceFrom)
+	{
+		return new Listing
+		{
+			Id = Guid.NewGuid(),
+			ExternalId = "ext-1",
+			Title = "Prodej domu",
+			Location = "Brno",
+			Url = "https://example.com/1",
+			ImageUrl = string.Empty,
+			CreatedAt = Now,
+			LastSeenAt = Now,
+			Price = price,
+			PriceFrom = priceFrom
+		};
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsNotFound_WhenListingDoesNotExist()
+	{
+		// Arrange
+		listingRepositoryMock
+			.Setup(x => x.GetWithPriceHistoryAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((Listing?)null);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetListingPriceHistoryQuery(Guid.NewGuid()), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsFailure);
+		Assert.Equal("Listing.NotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsOnlyCurrentPrice_WhenListingHasNoHistory()
+	{
+		// Arrange
+		var listing = CreateListing(5_000_000, Now);
+		listingRepositoryMock
+			.Setup(x => x.GetWithPriceHistoryAsync(listing.Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(listing);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetListingPriceHistoryQuery(listing.Id), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		var record = Assert.Single(result.Value);
+		Assert.Equal(5_000_000, record.Price);
+		Assert.Equal(Now, record.RecordedAt);
+		Assert.True(record.IsCurrent);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsHistoryOrderedByDateWithCurrentPriceLast()
+	{
+		// Arrange
+		var listing = CreateListing(4_500_000, Now);
+		listing.PriceHistories =
+		[
+			new PriceHistory { Price = 5_200_000, RecordedAt = Now.AddDays(-10) },
+			new PriceHistory { Price = 5_000_000, RecordedAt = Now.AddDays(-30) }
+		];
+		listingRepositoryMock
+			.Setup(x => x.GetWithPriceHistoryAsync(listing.Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(listing);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetListingPriceHistoryQuery(listing.Id), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(3, result.Value.Count);
+		Assert.Equal([5_000_000, 5_200_000, 4_500_000], result.Value.Select(r => r.Price));
+		Assert.Equal([Now.AddDays(-30), Now.AddDays(-10), Now], result.Value.Select(r => r.RecordedAt));
+		Assert.Equal([false, false, true], result.Value.Select(r => r.IsCurrent));
+	}
+}

--- a/Application/Features/Listings/GetPriceHistory/GetListingPriceHistoryQueryHandler.cs
+++ b/Application/Features/Listings/GetPriceHistory/GetListingPriceHistoryQueryHandler.cs
@@ -26,6 +26,14 @@ internal sealed class GetListingPriceHistoryQueryHandler : IQueryHandler<GetList
 			.Select(ListingMapper.MapToPriceHistoryDto)
 			.ToList();
 
+		// PriceHistories obsahují jen uzavřené cenové úseky — aktuální cena je na listingu
+		result.Add(new PriceHistoryDto
+		{
+			Price = listing.Price,
+			RecordedAt = listing.PriceFrom,
+			IsCurrent = true
+		});
+
 		return Result.Success(result);
 	}
 }

--- a/Application/Features/Listings/PriceHistoryDto.cs
+++ b/Application/Features/Listings/PriceHistoryDto.cs
@@ -5,4 +5,6 @@ public class PriceHistoryDto
 	public decimal? Price { get; set; }
 
 	public DateTimeOffset RecordedAt { get; set; }
+
+	public bool IsCurrent { get; set; }
 }

--- a/Web.Api/Mappers/Listings/ListingDtoMapper.cs
+++ b/Web.Api/Mappers/Listings/ListingDtoMapper.cs
@@ -37,7 +37,8 @@ public static class ListingDtoMapper
 		return new PriceHistoryResult
 		{
 			Price = dto.Price,
-			RecordedAt = dto.RecordedAt
+			RecordedAt = dto.RecordedAt,
+			IsCurrent = dto.IsCurrent
 		};
 	}
 }

--- a/Web.Client/Pages/Listings/ListingListPage.razor
+++ b/Web.Client/Pages/Listings/ListingListPage.razor
@@ -86,31 +86,61 @@
     </Columns>
 </HxGrid>
 
-<HxOffcanvas @ref="priceHistoryOffcanvas" Title="@priceHistoryOffcanvasTitle">
+<HxOffcanvas @ref="priceHistoryOffcanvas" Title="@priceHistoryOffcanvasTitle" Size="OffcanvasSize.Large">
     <BodyTemplate>
-        @if (selectedPriceHistory == null || selectedPriceHistory.Count == 0)
+        @if (priceHistoryRows == null || priceHistoryRows.Count == 0)
         {
             <p class="text-muted">Žádná historie cen není k dispozici.</p>
         }
         else
         {
-            <table class="table table-sm">
+            <div class="table-responsive">
+            <table class="table table-sm align-middle">
                 <thead>
                     <tr>
-                        <th>Datum</th>
+                        <th>Od</th>
                         <th class="text-end">Cena</th>
+                        <th class="text-end">Změna</th>
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach (var record in selectedPriceHistory)
+                    @foreach (var row in priceHistoryRows)
                     {
                         <tr>
-                            <td>@TimeZoneHelper.FormatLocal(record.RecordedAt)</td>
-                            <td class="text-end">@FormatPrice(record.Price)</td>
+                            <td class="text-nowrap">
+                                @TimeZoneHelper.FormatLocal(row.From)
+                                @if (row.IsCurrent)
+                                {
+                                    <HxBadge Color="ThemeColor.Success" CssClass="ms-2">Aktuální</HxBadge>
+                                }
+                            </td>
+                            <td class="text-end text-nowrap @(row.IsCurrent ? "fw-semibold" : null)">@FormatPrice(row.Price)</td>
+                            <td class="text-end">
+                                @if (row.Difference is { } difference && difference != 0)
+                                {
+                                    <span class="text-nowrap @(difference > 0 ? "text-danger" : "text-success")">
+                                        <HxIcon Icon="@(difference > 0 ? BootstrapIcon.CaretUpFill : BootstrapIcon.CaretDownFill)" />
+                                        @FormatSignedPrice(difference)
+                                        @if (row.DifferencePercent is { } percent)
+                                        {
+                                            <span> (@FormatSignedPercent(percent))</span>
+                                        }
+                                    </span>
+                                }
+                                else if (row.Difference == 0)
+                                {
+                                    <span class="text-muted">beze změny</span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted">—</span>
+                                }
+                            </td>
                         </tr>
                     }
                 </tbody>
             </table>
+            </div>
         }
     </BodyTemplate>
 </HxOffcanvas>

--- a/Web.Client/Pages/Listings/ListingListPage.razor.cs
+++ b/Web.Client/Pages/Listings/ListingListPage.razor.cs
@@ -28,7 +28,7 @@ public partial class ListingListPage(
 	private bool? activeFilter = true;
 	private Guid? scraperTaskFilter;
 	private string? searchTerm;
-	private List<PriceHistoryResult>? selectedPriceHistory;
+	private List<PriceHistoryRow>? priceHistoryRows;
 	private string priceHistoryOffcanvasTitle = "Historie cen";
 
 	protected override async Task OnInitializedAsync()
@@ -95,7 +95,8 @@ public partial class ListingListPage(
 	{
 		try
 		{
-			selectedPriceHistory = await http.GetFromJsonAsync<List<PriceHistoryResult>>($"/api/listings/{listing.Id}/price-history");
+			var history = await http.GetFromJsonAsync<List<PriceHistoryResult>>($"/api/listings/{listing.Id}/price-history") ?? [];
+			priceHistoryRows = BuildPriceHistoryRows(history);
 			priceHistoryOffcanvasTitle = $"Historie cen – {listing.Title}";
 			await priceHistoryOffcanvas.ShowAsync();
 		}
@@ -105,12 +106,58 @@ public partial class ListingListPage(
 		}
 	}
 
+	private static List<PriceHistoryRow> BuildPriceHistoryRows(List<PriceHistoryResult> history)
+	{
+		var rows = new List<PriceHistoryRow>(history.Count);
+		decimal? previousPrice = null;
+
+		foreach (var record in history.OrderBy(h => h.RecordedAt))
+		{
+			decimal? difference = null;
+			decimal? differencePercent = null;
+			if (record.Price.HasValue && previousPrice.HasValue)
+			{
+				difference = record.Price.Value - previousPrice.Value;
+				if (previousPrice.Value != 0)
+				{
+					differencePercent = difference.Value / previousPrice.Value * 100;
+				}
+			}
+
+			rows.Add(new PriceHistoryRow(record.RecordedAt, record.Price, difference, differencePercent, record.IsCurrent));
+			previousPrice = record.Price;
+		}
+
+		// nejnovější cena (aktuální) nahoře
+		rows.Reverse();
+		return rows;
+	}
+
 	private static string FormatPrice(decimal? price)
 	{
 		return price.HasValue
 			? string.Create(czechCulture, $"{price.Value:N0} Kč")
 			: "—";
 	}
+
+	private static string FormatSignedPrice(decimal difference)
+	{
+		var sign = difference > 0 ? "+" : "−";
+		return string.Create(czechCulture, $"{sign}{Math.Abs(difference):N0} Kč");
+	}
+
+	private static string FormatSignedPercent(decimal percent)
+	{
+		var sign = percent > 0 ? "+" : "−";
+		return string.Create(czechCulture, $"{sign}{Math.Abs(percent):N1} %");
+	}
+
+	private sealed record PriceHistoryRow(
+		DateTimeOffset From,
+		decimal? Price,
+		decimal? Difference,
+		decimal? DifferencePercent,
+		bool IsCurrent);
 
 	private record StateFilterOption(bool Value, string Name);
 }

--- a/Web.Shared/Models/Listings/PriceHistoryResult.cs
+++ b/Web.Shared/Models/Listings/PriceHistoryResult.cs
@@ -5,4 +5,6 @@ public class PriceHistoryResult
 	public decimal? Price { get; set; }
 
 	public DateTimeOffset RecordedAt { get; set; }
+
+	public bool IsCurrent { get; set; }
 }


### PR DESCRIPTION
## Shrnutí

Drawer s historií cen na stránce Reality dosud zobrazoval jen uzavřené cenové úseky z tabulky `PriceHistory` — aktuální cena a datum, od kdy platí (`Listing.PriceFrom`), v odpovědi API úplně chyběly. Nebyl tak vidět kompletní pohyb cen.

## Změny

- **API**: `GetListingPriceHistoryQuery` přidává na konec časové osy aktuální cenu listingu s příznakem `IsCurrent` — každý řádek odpovědi = cena + od kdy platila.
- **Drawer**: řádky od nejnovější (aktuální cena nahoře, tučně, s badgem „Aktuální“), sloupce Od | Cena | Změna. Rozdíl se počítá proti předchozí ceně a zobrazuje se šipkou a barvou: pokles zeleně `▼ −750 000 Kč (−9,6 %)`, růst červeně `▲ +300 000 Kč (+4,0 %)`; u výchozí ceny pomlčka, u záznamů bez ceny se rozdíl nepočítá.
- **Layout draweru**: `OffcanvasSize.Large` (širší na desktopu), `text-nowrap` na buňkách a `.table-responsive` obal — na mobilu tabulka scrolluje uvnitř draweru, nic nepřetéká.
- **Testy**: 3 nové unit testy pro `GetListingPriceHistoryQueryHandler` (not found, listing bez historie, řazení + aktuální cena na konci).

## Ověření

Celé Application.Tests zelené (65/65). Ověřeno naživo Playwrightem na desktopu (1400 px) i mobilu (390 px) s testovací historií cen v lokální DB — zobrazení rozdílů, barev, badge i scrollování v draweru fungují.