### PR TITLE
Feat: servisní endpoint pro dotažení chybějících náhledů inzerátů

### DIFF
--- a/Application/Features/Maintenance/BackfillListingImages/BackfillListingImagesCommand.cs
+++ b/Application/Features/Maintenance/BackfillListingImages/BackfillListingImagesCommand.cs
@@ -1,0 +1,14 @@
+using RealityScraper.Application.Abstractions.Messaging;
+
+namespace RealityScraper.Application.Features.Maintenance.BackfillListingImages;
+
+/// <summary>
+/// Dotáhne chybějící náhledové obrázky k živým inzerátům z jejich uložené URL.
+/// </summary>
+public record BackfillListingImagesCommand : ICommand<BackfillListingImagesResult>;
+
+public record BackfillListingImagesResult(
+	int CheckedCount,
+	int DownloadedCount,
+	int FailedCount,
+	int RemainingCount);

--- a/Application/Features/Maintenance/BackfillListingImages/BackfillListingImagesCommandHandler.cs
+++ b/Application/Features/Maintenance/BackfillListingImages/BackfillListingImagesCommandHandler.cs
@@ -1,0 +1,81 @@
+using RealityScraper.Application.Abstractions.Messaging;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.Application.Interfaces.Scraping;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Features.Maintenance.BackfillListingImages;
+
+internal sealed class BackfillListingImagesCommandHandler
+	: ICommandHandler<BackfillListingImagesCommand, BackfillListingImagesResult>
+{
+	// Pojistka, aby request nevisel, kdyby chybějících snímků bylo proti očekávání hodně.
+	// Zbytek se dotáhne dalším zavoláním - RemainingCount řekne, kolik jich ještě zbývá.
+	private const int MaxDownloadsPerRun = 200;
+
+	private readonly IListingRepository listingRepository;
+	private readonly IListingImageReader listingImageReader;
+	private readonly IImageDownloadService imageDownloadService;
+
+	public BackfillListingImagesCommandHandler(
+		IListingRepository listingRepository,
+		IListingImageReader listingImageReader,
+		IImageDownloadService imageDownloadService)
+	{
+		this.listingRepository = listingRepository;
+		this.listingImageReader = listingImageReader;
+		this.imageDownloadService = imageDownloadService;
+	}
+
+	public async Task<Result<BackfillListingImagesResult>> Handle(
+		BackfillListingImagesCommand command,
+		CancellationToken cancellationToken)
+	{
+		var listings = await listingRepository.GetActiveWithImageUrlAsync(cancellationToken);
+
+		var downloadedCount = 0;
+		var failedCount = 0;
+		var remainingCount = 0;
+
+		foreach (var listing in listings)
+		{
+			if (listingImageReader.ImageExists(listing.Id))
+			{
+				continue;
+			}
+
+			if (downloadedCount + failedCount >= MaxDownloadsPerRun)
+			{
+				remainingCount++;
+				continue;
+			}
+
+			try
+			{
+				await imageDownloadService.DownloadImageAsync(listing, cancellationToken);
+
+				// DownloadImageAsync vrací void a tiše přeskakuje neplatnou URL, nepovolený
+				// cíl i odpověď bez Content-Type "image/*" - jediný spolehlivý test úspěchu
+				// je existence souboru po volání.
+				if (listingImageReader.ImageExists(listing.Id))
+				{
+					downloadedCount++;
+				}
+				else
+				{
+					failedCount++;
+				}
+			}
+			catch (Exception ex) when (ex is not OperationCanceledException)
+			{
+				// Chyba u jednoho inzerátu nesmí zastavit dotahování ostatních.
+				failedCount++;
+			}
+		}
+
+		return Result.Success(new BackfillListingImagesResult(
+			listings.Count,
+			downloadedCount,
+			failedCount,
+			remainingCount));
+	}
+}

--- a/Application/Interfaces/Repositories/Realty/IListingRepository.cs
+++ b/Application/Interfaces/Repositories/Realty/IListingRepository.cs
@@ -10,6 +10,11 @@ public interface IListingRepository
 
 	Task<List<Listing>> GetByScraperTaskIdAsync(Guid scraperTaskId, CancellationToken cancellationToken);
 
+	/// <summary>
+	/// Živé inzeráty (dosud nevyřazené) se zadanou URL obrázku, napříč všemi scraper úlohami.
+	/// </summary>
+	Task<List<Listing>> GetActiveWithImageUrlAsync(CancellationToken cancellationToken);
+
 	Task<List<Listing>> GetRemovedInPeriodAsync(Guid scraperTaskId, DateTimeOffset fromExclusive, DateTimeOffset toInclusive, CancellationToken cancellationToken);
 
 	Task<(List<Listing> Items, int TotalCount)> GetPagedAsync(bool? isActive, Guid? scraperTaskId, string? searchTerm, int skip, int take, CancellationToken cancellationToken);

--- a/Application/Interfaces/Scraping/IListingImageReader.cs
+++ b/Application/Interfaces/Scraping/IListingImageReader.cs
@@ -7,4 +7,9 @@ public interface IListingImageReader
 	/// Vrací null, pokud obrázek není k dispozici.
 	/// </summary>
 	Task<byte[]?> TryReadImageAsync(Guid listingId, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Levná kontrola, zda je obrázek inzerátu nakešovaný, bez načítání jeho obsahu.
+	/// </summary>
+	bool ImageExists(Guid listingId);
 }

--- a/Infrastructure/Repositories/Realty/ListingRepository.cs
+++ b/Infrastructure/Repositories/Realty/ListingRepository.cs
@@ -27,6 +27,15 @@ internal class ListingRepository : Repository<Listing>, IListingRepository
 			.ToListAsync(cancellationToken);
 	}
 
+	public Task<List<Listing>> GetActiveWithImageUrlAsync(CancellationToken cancellationToken)
+	{
+		return dbContext
+			.Set<Listing>()
+			.AsNoTracking()
+			.Where(x => x.RemovedAt == null && x.ImageUrl != "")
+			.ToListAsync(cancellationToken);
+	}
+
 	public async Task<(List<Listing> Items, int TotalCount)> GetPagedAsync(bool? isActive, Guid? scraperTaskId, string? searchTerm, int skip, int take, CancellationToken cancellationToken)
 	{
 		var query = dbContext

--- a/Infrastructure/Utilities/ListingImageReader.cs
+++ b/Infrastructure/Utilities/ListingImageReader.cs
@@ -14,6 +14,11 @@ public class ListingImageReader : IListingImageReader
 		this.logger = logger;
 	}
 
+	public bool ImageExists(Guid listingId)
+	{
+		return File.Exists(pathResolver.GetImageFilePath(listingId));
+	}
+
 	public async Task<byte[]?> TryReadImageAsync(Guid listingId, CancellationToken cancellationToken)
 	{
 		var imageFilePath = pathResolver.GetImageFilePath(listingId);

--- a/Web.Api/Endpoints/Maintenance/BackfillListingImagesEndpoint.cs
+++ b/Web.Api/Endpoints/Maintenance/BackfillListingImagesEndpoint.cs
@@ -1,0 +1,22 @@
+using RealityScraper.Application.Abstractions.Messaging;
+using RealityScraper.Application.Features.Maintenance.BackfillListingImages;
+using RealityScraper.Web.Api.Infrastructure;
+
+namespace RealityScraper.Web.Api.Endpoints.Maintenance;
+
+internal sealed class BackfillListingImagesEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapPost("/api/maintenance/listing-images/backfill", async (
+			ICommandHandler<BackfillListingImagesCommand, BackfillListingImagesResult> commandHandler,
+			CancellationToken cancellationToken) =>
+		{
+			var result = await commandHandler.Handle(new BackfillListingImagesCommand(), cancellationToken);
+
+			return result.IsSuccess
+				? Results.Ok(result.Value)
+				: CustomResults.Problem(result);
+		});
+	}
+}


### PR DESCRIPTION
## Shrnutí

Během historických přesunů mezi hostingy a kvůli problémům s oprávněními se ztratily soubory náhledových obrázků u části inzerátů. Běžný provoz je nedoplní — `ListingChangeProcessor.ProcessChangesAsync` vrací ke stažení jen nově vložené inzeráty, `ImageUrl` u existujících se nikdy neaktualizuje a `ImageDownloadService` neúspěch jen zaloguje jako warning a nikdy neopakuje.

Chybějící náhled se projeví na jediném místě, zato tam, kde na něm záleží: v týdenním reportu vyřazených inzerátů se místo snímku vykreslí placeholder 🏠. Stránka Reality obrázky z disku vůbec nečte, hotlinkuje `Listing.ImageUrl` z portálu. Lokální cache je tedy pojistka — jakmile inzerát z portálu zmizí, jediná kopie obrázku je ta naše. Proto je potřeba ji doplnit, **dokud jsou inzeráty živé**.

## Změny

- **Endpoint**: `POST /api/maintenance/listing-images/backfill` projde živé inzeráty (`RemovedAt IS NULL`) s vyplněnou `ImageUrl` a chybějící náhledy dotáhne z uložené URL. Vrací souhrn `{ checkedCount, downloadedCount, failedCount, remainingCount }`. Autorizaci i rate limiting dědí ze společné skupiny endpointů.
- **`IListingImageReader.ImageExists(Guid)`**: levná sonda na existenci nakešovaného souboru. `TryReadImageAsync` načítá celý soubor do paměti, na pouhou kontrolu je to plýtvání — a `File.Exists` nepatří do Application vrstvy, rozvržení úložiště zná jedině `ListingImagePathResolver`.
- **`IListingRepository.GetActiveWithImageUrlAsync`**: dotaz na živé inzeráty napříč všemi scraper úlohami (stávající metody jsou vždy per-task). `AsNoTracking`, bez stránkování — řádky jsou malé.
- **Ošetření tichých přeskočení**: `DownloadImageAsync` vrací `void` a bez chyby se vrátí u neplatné URL, nepovoleného cíle i odpovědi bez `Content-Type: image/*`. Kdyby se „nevyhodilo to výjimku“ bralo jako úspěch, tyhle případy by se počítaly jako stažené — proto se po každém volání znovu ověří existence souboru.
- **Limit 200 stažení na volání**: pojistka proti visícímu requestu. Zbytek hlásí `remainingCount`, stačí zavolat znovu.

Žádná EF migrace (schéma se nemění) a žádná změna v DI — handler i endpoint se registrují automaticky.

## Ověření

Ověřeno naživo proti lokální DB. 3 živé inzeráty s reálnou URL → `downloadedCount: 3`, na disku skutečné JPEGy 160×120 ve správných shardech (`{id[..2]}/{id}.jpg`). Druhé volání `downloadedCount: 0` (idempotence, nic se nestahuje zbytečně).

Chybové cesty: URL vracející 404 a URL vracející HTML → `failedCount: 2`, smyčka pokračovala a už nakešovaný inzerát správně přeskočila. V logu potvrzeno `Odpověď pro obrázek inzerátu … má neočekávaný Content-Type 'text/html'` — tedy přesně ten tichý případ, který post-kontrola odchytí.

Celá testovací sada zelená (113/113). Testovací data i soubory po ověření vráceny do původního stavu.

## Známé omezení

Stahuje se z **uložené** `ImageUrl`, která se od vzniku inzerátu nikdy neaktualizuje a u starších inzerátů může být mrtvá. U živých inzerátů by měla platit, ale pokud v produkci vyjde vysoký `failedCount`, pomohlo by až doplňování z čerstvé URL při scrapu — ta se dnes při každém běhu načte a zahodí.