### PR TITLE
Chore: aktualizace NuGet balíčků a přechod testů na Microsoft Testing Platform

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c Release
     - name: Test
-      run: dotnet test --no-build -c Release --verbosity normal --logger "trx" --collect:"XPlat Code Coverage" --results-directory ./TestResults
+      run: dotnet test --no-build -c Release --verbosity normal --report-trx --coverage --coverage-output-format cobertura --results-directory ./TestResults
     - name: Upload test results
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
@@ -38,5 +38,5 @@ jobs:
         name: test-results
         path: |
           ./TestResults/**/*.trx
-          ./TestResults/**/coverage.cobertura.xml
+          ./TestResults/**/*.cobertura.xml
         if-no-files-found: ignore

--- a/Application.Tests/Application.Tests.csproj
+++ b/Application.Tests/Application.Tests.csproj
@@ -9,15 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="FluentAssertions.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,47 +4,46 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Blazilla" Version="2.4.0" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Blazilla" Version="2.4.1" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
-    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
-    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.34.1" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageVersion Include="Havit.Blazor.Components.Web.Bootstrap" Version="4.25.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
+    <PackageVersion Include="Havit.Blazor.Components.Web.Bootstrap" Version="4.26.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <!-- Úmyslný pin: Microsoft.AspNetCore.OpenApi jinak transitivně resolvuje deprecated/zranitelnou verzi Microsoft.OpenApi 2.0.0 (NU1903, GHSA-v5pm-xwqc-g5wc) -->
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
+    <!-- Úmyslný pin: Microsoft.AspNetCore.OpenApi jinak transitivně resolvuje deprecated/zranitelnou verzi Microsoft.OpenApi 2.0.0 (NU1903, GHSA-v5pm-xwqc-g5wc).
+         Držet na 2.x – Microsoft.AspNetCore.OpenApi 10.0.x vyžaduje [2.7.5, 3.0.0) a s 3.x nejde přeložit generovaný OpenApiXmlCommentSupport (IOpenApiMediaType.Example je read-only). -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.12.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="RazorEngineCore" Version="2026.1.1" />
-    <PackageVersion Include="Resend" Version="0.6.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.12" />
+    <PackageVersion Include="Resend" Version="0.10.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.20" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
-    <PackageVersion Include="Selenium.Support" Version="4.46.0" />
-    <PackageVersion Include="Selenium.WebDriver" Version="4.46.0" />
+    <PackageVersion Include="Selenium.Support" Version="4.47.0" />
+    <PackageVersion Include="Selenium.WebDriver" Version="4.47.0" />
     <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
-    <PackageVersion Include="WebDriverManager" Version="2.17.7" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/Domain.Tests/Domain.Tests.csproj
+++ b/Domain.Tests/Domain.Tests.csproj
@@ -9,15 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="FluentAssertions.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/Domain.Tests/Entities/EntityEqualityTests.cs
+++ b/Domain.Tests/Entities/EntityEqualityTests.cs
@@ -1,0 +1,62 @@
+﻿using RealityScraper.Domain.Entities.Realty;
+
+namespace RealityScraper.Domain.Tests.Entities;
+
+// Entity porovnává podle Id a konkrétního typu (viz SharedKernel.Entity)
+public class EntityEqualityTests
+{
+	[Fact]
+	public void Equals_SameTypeAndSameId_AreEqual()
+	{
+		var id = Guid.NewGuid();
+		var first = new Listing { Id = id, Title = "Chalupa" };
+		var second = new Listing { Id = id, Title = "Úplně jiný titulek" };
+
+		Assert.True(first.Equals(second));
+		Assert.True(first == second);
+		Assert.False(first != second);
+		Assert.Equal(first.GetHashCode(), second.GetHashCode());
+	}
+
+	[Fact]
+	public void Equals_SameTypeDifferentId_AreNotEqual()
+	{
+		var first = new Listing { Id = Guid.NewGuid() };
+		var second = new Listing { Id = Guid.NewGuid() };
+
+		Assert.False(first.Equals(second));
+		Assert.True(first != second);
+	}
+
+	[Fact]
+	public void Equals_DifferentTypeWithSameId_AreNotEqual()
+	{
+		var id = Guid.NewGuid();
+		var listing = new Listing { Id = id };
+		var priceHistory = new PriceHistory { Id = id };
+
+		Assert.False(listing.Equals(priceHistory));
+		Assert.False(priceHistory.Equals(listing));
+	}
+
+	[Fact]
+	public void Equals_NonEntityObject_IsNotEqual()
+	{
+		var listing = new Listing { Id = Guid.NewGuid() };
+
+		Assert.False(listing.Equals("nejsem entita"));
+		Assert.False(listing.Equals(null));
+	}
+
+	[Fact]
+	public void EqualityOperator_HandlesNullOnBothSides()
+	{
+		Listing? nullListing = null;
+		var listing = new Listing { Id = Guid.NewGuid() };
+
+		Assert.True(nullListing == null);
+		Assert.False(nullListing == listing);
+		Assert.False(listing == nullListing);
+		Assert.True(listing != nullListing);
+	}
+}

--- a/Domain.Tests/Entities/Tasks/RemovedListingsReportTaskTests.cs
+++ b/Domain.Tests/Entities/Tasks/RemovedListingsReportTaskTests.cs
@@ -1,0 +1,57 @@
+﻿using RealityScraper.Domain.Entities.Tasks;
+
+namespace RealityScraper.Domain.Tests.Entities.Tasks;
+
+public class RemovedListingsReportTaskTests
+{
+	private static RemovedListingsReportTask CreateTask()
+	{
+		return new RemovedListingsReportTask(
+			name: "Týdenní přehled stažených inzerátů",
+			cronExpression: "0 7 * * 1",
+			enabled: true,
+			createdAt: new DateTimeOffset(2026, 1, 15, 7, 0, 0, TimeSpan.Zero),
+			nextRunAt: new DateTimeOffset(2026, 1, 19, 7, 0, 0, TimeSpan.Zero));
+	}
+
+	[Fact]
+	public void AddRecipient_SetsBackReferenceToTask()
+	{
+		var task = CreateTask();
+		task.Id = Guid.NewGuid();
+		var recipient = new ReportTaskRecipient("info@example.com");
+
+		task.AddRecipient(recipient);
+
+		Assert.Same(task, recipient.ReportTask);
+		Assert.Equal(task.Id, recipient.ReportTaskId);
+		Assert.Equal(recipient, Assert.Single(task.Recipients));
+	}
+
+	[Fact]
+	public void RemoveRecipient_RemovesOnlyGivenRecipient()
+	{
+		var task = CreateTask();
+		var first = new ReportTaskRecipient("prvni@example.com");
+		var second = new ReportTaskRecipient("druhy@example.com");
+		task.AddRecipient(first);
+		task.AddRecipient(second);
+
+		task.RemoveRecipient(first);
+
+		Assert.Equal("druhy@example.com", Assert.Single(task.Recipients).Email);
+	}
+
+	[Fact]
+	public void SetLastSuccessfulReportAt_IsNullUntilFirstReportIsSent()
+	{
+		var task = CreateTask();
+		var sentAt = new DateTimeOffset(2026, 1, 19, 7, 0, 0, TimeSpan.Zero);
+
+		Assert.Null(task.LastSuccessfulReportAt);
+
+		task.SetLastSuccessfulReportAt(sentAt);
+
+		Assert.Equal(sentAt, task.LastSuccessfulReportAt);
+	}
+}

--- a/Domain.Tests/Entities/Tasks/ScraperTaskTests.cs
+++ b/Domain.Tests/Entities/Tasks/ScraperTaskTests.cs
@@ -1,0 +1,125 @@
+﻿using RealityScraper.Domain.Entities.Tasks;
+using RealityScraper.Domain.Enums;
+using RealityScraper.Domain.Events;
+
+namespace RealityScraper.Domain.Tests.Entities.Tasks;
+
+public class ScraperTaskTests
+{
+	private static ScraperTask CreateTask()
+	{
+		return new ScraperTask(
+			name: "Denní sken",
+			cronExpression: "0 6 * * *",
+			enabled: true,
+			createdAt: new DateTimeOffset(2026, 1, 15, 6, 0, 0, TimeSpan.Zero),
+			nextRunAt: new DateTimeOffset(2026, 1, 16, 6, 0, 0, TimeSpan.Zero));
+	}
+
+	[Fact]
+	public void Constructor_SetsProvidedValues()
+	{
+		var createdAt = new DateTimeOffset(2026, 1, 15, 6, 0, 0, TimeSpan.Zero);
+		var nextRunAt = new DateTimeOffset(2026, 1, 16, 6, 0, 0, TimeSpan.Zero);
+
+		var task = new ScraperTask("Denní sken", "0 6 * * *", enabled: true, createdAt, nextRunAt);
+
+		Assert.Equal("Denní sken", task.Name);
+		Assert.Equal("0 6 * * *", task.CronExpression);
+		Assert.True(task.Enabled);
+		Assert.Equal(createdAt, task.CreatedAt);
+		Assert.Equal(nextRunAt, task.NextRunAt);
+		Assert.Null(task.LastRunAt);
+	}
+
+	[Fact]
+	public void AddRecipient_SetsBackReferenceToTask()
+	{
+		var task = CreateTask();
+		task.Id = Guid.NewGuid();
+		var recipient = new ScraperTaskRecipient("info@example.com");
+
+		task.AddRecipient(recipient);
+
+		Assert.Same(task, recipient.ScraperTask);
+		Assert.Equal(task.Id, recipient.ScraperTaskId);
+		Assert.Equal(recipient, Assert.Single(task.Recipients));
+	}
+
+	[Fact]
+	public void AddTarget_SetsBackReferenceToTask()
+	{
+		var task = CreateTask();
+		task.Id = Guid.NewGuid();
+		var target = new ScraperTaskTarget(ScrapersEnum.SReality, "https://www.sreality.cz/hledani/prodej/domy");
+
+		task.AddTarget(target);
+
+		Assert.Same(task, target.ScraperTask);
+		Assert.Equal(task.Id, target.ScraperTaskId);
+		Assert.Equal(ScrapersEnum.SReality, Assert.Single(task.Targets).ScraperType);
+	}
+
+	[Fact]
+	public void RemoveRecipient_RemovesOnlyGivenRecipient()
+	{
+		var task = CreateTask();
+		var first = new ScraperTaskRecipient("prvni@example.com");
+		var second = new ScraperTaskRecipient("druhy@example.com");
+		task.AddRecipient(first);
+		task.AddRecipient(second);
+
+		task.RemoveRecipient(first);
+
+		Assert.Equal("druhy@example.com", Assert.Single(task.Recipients).Email);
+	}
+
+	[Fact]
+	public void RemoveTarget_RemovesOnlyGivenTarget()
+	{
+		var task = CreateTask();
+		var first = new ScraperTaskTarget(ScrapersEnum.SReality, "https://www.sreality.cz/a");
+		var second = new ScraperTaskTarget(ScrapersEnum.RealityIdnes, "https://reality.idnes.cz/b");
+		task.AddTarget(first);
+		task.AddTarget(second);
+
+		task.RemoveTarget(first);
+
+		Assert.Equal(ScrapersEnum.RealityIdnes, Assert.Single(task.Targets).ScraperType);
+	}
+
+	[Fact]
+	public void Setters_OverwritePlannedRunState()
+	{
+		var task = CreateTask();
+		var lastRunAt = new DateTimeOffset(2026, 1, 16, 6, 0, 0, TimeSpan.Zero);
+
+		task.SetLastRunAt(lastRunAt);
+		task.SetNextRunAt(null);
+		task.SetEnabled(false);
+		task.SetLastRunSucceeded(false);
+		task.SetLastRunLog("timeout");
+
+		Assert.Equal(lastRunAt, task.LastRunAt);
+		Assert.Null(task.NextRunAt);
+		Assert.False(task.Enabled);
+		Assert.False(task.LastRunSucceeded);
+		Assert.Equal("timeout", task.LastRunLog);
+	}
+
+	[Fact]
+	public void RaiseDomainEvent_CollectsEventsUntilCleared()
+	{
+		var task = CreateTask();
+		task.Id = Guid.NewGuid();
+		var createdEvent = new ScraperTaskCreatedEvent(task.Id);
+
+		task.RaiseDomainEvent(createdEvent);
+
+		Assert.Same(createdEvent, Assert.Single(task.DomainEvents));
+
+		task.ClearDomainEvents();
+
+		Assert.Empty(task.DomainEvents);
+	}
+}

--- a/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -9,15 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="FluentAssertions.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Resend" />
     <PackageReference Include="Selenium.Support" />
     <PackageReference Include="Selenium.WebDriver" />
-    <PackageReference Include="WebDriverManager" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IntegrationTests/Database/RealityDbContextModelTests.cs
+++ b/IntegrationTests/Database/RealityDbContextModelTests.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore;
+using RealityScraper.Domain.Entities.Realty;
+using RealityScraper.Domain.Entities.Tasks;
+using RealityScraper.Infrastructure.Contexts;
+
+namespace RealityScraper.IntegrationTests.Database;
+
+// Ověřuje, že se EF model poskládá z konfigurací v Infrastructure a sedí na migrace.
+// Nepotřebuje běžící databázi – Npgsql provider model sestaví i bez připojení.
+public class RealityDbContextModelTests
+{
+	private static RealityDbContext CreateContext()
+	{
+		var options = new DbContextOptionsBuilder<RealityDbContext>()
+			.UseNpgsql("Host=localhost;Database=reality_scraper;Username=test;Password=test")
+			.Options;
+
+		return new RealityDbContext(options);
+	}
+
+	[Theory]
+	[InlineData(typeof(Listing))]
+	[InlineData(typeof(PriceHistory))]
+	[InlineData(typeof(ScraperTask))]
+	[InlineData(typeof(ScraperTaskRecipient))]
+	[InlineData(typeof(ScraperTaskTarget))]
+	[InlineData(typeof(RemovedListingsReportTask))]
+	[InlineData(typeof(ReportTaskRecipient))]
+	[InlineData(typeof(ReportTaskSource))]
+	public void Model_MapsEntity(Type entityType)
+	{
+		using var context = CreateContext();
+
+		Assert.NotNull(context.Model.FindEntityType(entityType));
+	}
+
+	[Fact]
+	public void Model_EveryEntityHasPrimaryKey()
+	{
+		using var context = CreateContext();
+
+		var withoutKey = context.Model.GetEntityTypes()
+			.Where(e => !e.IsOwned() && e.FindPrimaryKey() is null)
+			.Select(e => e.Name)
+			.ToList();
+
+		Assert.Empty(withoutKey);
+	}
+
+	[Fact]
+	public void Model_HasNoPendingChangesAgainstMigrations()
+	{
+		using var context = CreateContext();
+
+		// Když tohle spadne, model se změnil a chybí k němu migrace
+		// (dotnet ef migrations add ... v projektu Infrastructure).
+		Assert.False(context.Database.HasPendingModelChanges());
+	}
+}

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -9,21 +9,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="FluentAssertions.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "10.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }


### PR DESCRIPTION
## Proč

Aktualizace NuGet balíčků rozbila build. Oprava se ale ukázala jako začátek delší nitky — xunit.v3 4.0 je major bump, který si vynutil změnu způsobu, jakým se v repu vůbec spouštějí testy.

## Oprava buildu

`Microsoft.OpenApi` vyskočil na 3.10.0, ale `Microsoft.AspNetCore.OpenApi 10.0.11` požaduje `[2.7.5, 3.0.0)`. NuGet to jen ohlásil warningem NU1608 a resolvoval 3.10.0; v OpenAPI 3.x je `IOpenApiMediaType.Example` read-only, takže se přestal překládat kód generovaný ASP.NET source generátorem (2× CS0200). Vráceno na nejnovější 2.x, tedy **2.12.0**. Důvod je zapsaný v komentáři u pinu, ať to příště nespadne stejně — uvolní se to až s další major verzí ASP.NET Core, protože v rámci 10.0.x by rozšíření toho rozsahu byla breaking change.

## Přechod na Microsoft Testing Platform

`xunit.v3` 4.0.0 nově závisí na `xunit.v3.mtp-v2` a VSTest cesta na .NET 10 SDK končí — `dotnet test` padal na `Testing with VSTest target is no longer supported`. Řešením je opt-in v `global.json` (`"test": { "runner": "Microsoft.Testing.Platform" }`).

Pozor na tichou past v CI: `--logger "trx"` a `--collect:"XPlat Code Coverage"` pod MTP **nespadnou na chybu — jen se neprovede žádný test**. Workflow proto přechází na `--report-trx --coverage --coverage-output-format cobertura`, což vyžaduje extension balíčky `Microsoft.Testing.Extensions.TrxReport` a `.CodeCoverage` (nahradily `coverlet.collector`, který je VSTest data collector a pod MTP nedělá nic). Cobertura soubory se nově jmenují GUIDem, takže upload glob je `*.cobertura.xml`. `Microsoft.NET.Test.Sdk` a `xunit.runner.visualstudio` zůstávají — pod MTP nevadí a xUnit je doporučuje držet kvůli IDE.

## Odstraněné balíčky

`WebDriverManager` se v repu nikde nepoužíval (driver se bere z nakonfigurované `DriverPath` nebo ze Selenium hubu), ale tranzitivně tahal `AngleSharp 1.1.2` se zranitelností [GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg) — mXSS přes `annotation-xml`, opravené až v 1.5.0. Aktualizace by nepomohla, 2.17.7 je poslední verze WebDriverManageru. Reálná expozice byla nulová (AngleSharp se nepoužíval k sanitizaci ničeho), ale balíček byl mrtvá závislost, takže šel pryč celý. Build je díky tomu **bez varování**.

`FluentAssertions` + `FluentAssertions.Analyzers` byly také nepoužívané, testy jsou psané čistým xUnit `Assert`.

## Nové testy

MTP nově vrací chybu (exit code 8) za testovací projekt, ve kterém neběžel žádný test. `Domain.Tests` a `IntegrationTests` přitom obsahovaly jen `.csproj` — pod VSTestem to bylo varování, teď by shodily CI. Dostaly proto skutečné testy:

- **Domain.Tests** — chování agregátů (`AddRecipient`/`AddTarget` nastavují zpětnou referenci, `Remove*` odebírá jen daný prvek), sbírání a čištění domain events, sémantika `Entity` rovnosti včetně null na obou stranách operátoru.
- **IntegrationTests** — složení EF modelu z konfigurací v Infrastructure nad Npgsql providerem, bez běžící databáze. Nejcennější je `Model_HasNoPendingChangesAgainstMigrations`, které hlídá drift modelu vůči migracím; ověřeno, že má zuby — po dočasném přidání sloupce do `Listing` test spadl.