### PR TITLE
Test: doplnění pokrytí pro backfill obrázků, scraping pipeline a scheduler

### DIFF
--- a/Application.Tests/Features/Maintenance/BackfillListingImagesCommandHandlerTests.cs
+++ b/Application.Tests/Features/Maintenance/BackfillListingImagesCommandHandlerTests.cs
@@ -1,0 +1,219 @@
+using Moq;
+using RealityScraper.Application.Features.Maintenance.BackfillListingImages;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.Application.Interfaces.Scraping;
+using RealityScraper.Domain.Entities.Realty;
+
+namespace RealityScraper.Application.Tests.Features.Maintenance;
+
+public class BackfillListingImagesCommandHandlerTests
+{
+	// Musí odpovídat MaxDownloadsPerRun v handleru.
+	private const int MaxDownloadsPerRun = 200;
+
+	private static readonly DateTimeOffset Now = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+	private readonly Mock<IListingRepository> listingRepositoryMock = new();
+	private readonly Mock<IListingImageReader> imageReaderMock = new();
+	private readonly Mock<IImageDownloadService> imageDownloadServiceMock = new();
+
+	private BackfillListingImagesCommandHandler CreateSut()
+	{
+		return new BackfillListingImagesCommandHandler(
+			listingRepositoryMock.Object,
+			imageReaderMock.Object,
+			imageDownloadServiceMock.Object);
+	}
+
+	private static Listing CreateListing(string externalId = "ext-1")
+	{
+		return new Listing
+		{
+			Id = Guid.NewGuid(),
+			ExternalId = externalId,
+			Title = "Prodej domu",
+			Location = "Brno",
+			Url = "https://example.com/1",
+			ImageUrl = "https://example.com/1.jpg",
+			CreatedAt = Now,
+			LastSeenAt = Now,
+			PriceFrom = Now
+		};
+	}
+
+	private void SetupListings(params Listing[] listings)
+	{
+		listingRepositoryMock
+			.Setup(x => x.GetActiveWithImageUrlAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(listings.ToList());
+	}
+
+	/// <summary>
+	/// Nasimuluje stažení obrázku: po zavolání DownloadImageAsync začne ImageExists vracet true.
+	/// </summary>
+	private void SetupSuccessfulDownloads(IEnumerable<Guid>? alreadyCached = null)
+	{
+		var stored = alreadyCached?.ToHashSet() ?? new HashSet<Guid>();
+
+		imageReaderMock
+			.Setup(x => x.ImageExists(It.IsAny<Guid>()))
+			.Returns((Guid id) => stored.Contains(id));
+
+		imageDownloadServiceMock
+			.Setup(x => x.DownloadImageAsync(It.IsAny<Listing>(), It.IsAny<CancellationToken>()))
+			.Callback((Listing listing, CancellationToken _) => stored.Add(listing.Id))
+			.Returns(Task.CompletedTask);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsZeroCounts_WhenThereAreNoListings()
+	{
+		// Arrange
+		SetupListings();
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new BackfillListingImagesCommand(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(new BackfillListingImagesResult(0, 0, 0, 0), result.Value);
+		imageDownloadServiceMock.Verify(
+			x => x.DownloadImageAsync(It.IsAny<Listing>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_SkipsListingsThatAlreadyHaveImage()
+	{
+		// Arrange
+		var withImage = CreateListing("ext-1");
+		var withoutImage = CreateListing("ext-2");
+		SetupListings(withImage, withoutImage);
+		SetupSuccessfulDownloads([withImage.Id]);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new BackfillListingImagesCommand(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(2, result.Value.CheckedCount);
+		Assert.Equal(1, result.Value.DownloadedCount);
+		Assert.Equal(0, result.Value.FailedCount);
+		imageDownloadServiceMock.Verify(x => x.DownloadImageAsync(withImage, It.IsAny<CancellationToken>()), Times.Never);
+		imageDownloadServiceMock.Verify(x => x.DownloadImageAsync(withoutImage, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_CountsAsFailed_WhenDownloadSilentlySkipsTheImage()
+	{
+		// Arrange
+		// DownloadImageAsync vrací void i když nic neuloží (neplatná URL, nepovolený cíl,
+		// odpověď bez Content-Type image/*) - handler to pozná jen podle chybějícího souboru.
+		SetupListings(CreateListing());
+		imageReaderMock.Setup(x => x.ImageExists(It.IsAny<Guid>())).Returns(false);
+		imageDownloadServiceMock
+			.Setup(x => x.DownloadImageAsync(It.IsAny<Listing>(), It.IsAny<CancellationToken>()))
+			.Returns(Task.CompletedTask);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new BackfillListingImagesCommand(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(1, result.Value.CheckedCount);
+		Assert.Equal(0, result.Value.DownloadedCount);
+		Assert.Equal(1, result.Value.FailedCount);
+		Assert.Equal(0, result.Value.RemainingCount);
+	}
+
+	[Fact]
+	public async Task Handle_CountsAsFailedAndContinues_WhenDownloadThrows()
+	{
+		// Arrange
+		var failing = CreateListing("ext-1");
+		var succeeding = CreateListing("ext-2");
+		SetupListings(failing, succeeding);
+		SetupSuccessfulDownloads();
+		imageDownloadServiceMock
+			.Setup(x => x.DownloadImageAsync(failing, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("boom"));
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new BackfillListingImagesCommand(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(2, result.Value.CheckedCount);
+		Assert.Equal(1, result.Value.DownloadedCount);
+		Assert.Equal(1, result.Value.FailedCount);
+		imageDownloadServiceMock.Verify(x => x.DownloadImageAsync(succeeding, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_PropagatesCancellation()
+	{
+		// Arrange
+		SetupListings(CreateListing(), CreateListing("ext-2"));
+		imageReaderMock.Setup(x => x.ImageExists(It.IsAny<Guid>())).Returns(false);
+		imageDownloadServiceMock
+			.Setup(x => x.DownloadImageAsync(It.IsAny<Listing>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new OperationCanceledException());
+		var sut = CreateSut();
+
+		// Act & Assert
+		await Assert.ThrowsAsync<OperationCanceledException>(
+			() => sut.Handle(new BackfillListingImagesCommand(), CancellationToken.None));
+	}
+
+	[Fact]
+	public async Task Handle_StopsAtMaxDownloadsPerRun_AndReportsRemaining()
+	{
+		// Arrange
+		var listings = Enumerable.Range(0, MaxDownloadsPerRun + 5)
+			.Select(i => CreateListing($"ext-{i}"))
+			.ToArray();
+		SetupListings(listings);
+		SetupSuccessfulDownloads();
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new BackfillListingImagesCommand(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(MaxDownloadsPerRun + 5, result.Value.CheckedCount);
+		Assert.Equal(MaxDownloadsPerRun, result.Value.DownloadedCount);
+		Assert.Equal(0, result.Value.FailedCount);
+		Assert.Equal(5, result.Value.RemainingCount);
+		imageDownloadServiceMock.Verify(
+			x => x.DownloadImageAsync(It.IsAny<Listing>(), It.IsAny<CancellationToken>()),
+			Times.Exactly(MaxDownloadsPerRun));
+	}
+
+	[Fact]
+	public async Task Handle_DoesNotCountAlreadyCachedListingsTowardsTheLimit()
+	{
+		// Arrange
+		// Inzeráty s hotovým obrázkem se přeskakují dřív, než se sáhne na limit,
+		// takže jich může projít libovolně mnoho.
+		var cached = Enumerable.Range(0, MaxDownloadsPerRun + 50)
+			.Select(i => CreateListing($"cached-{i}"))
+			.ToArray();
+		var missing = CreateListing("missing");
+		SetupListings([.. cached, missing]);
+		SetupSuccessfulDownloads(cached.Select(l => l.Id));
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new BackfillListingImagesCommand(), CancellationToken.None);
+
+		// Assert
+		Assert.Equal(cached.Length + 1, result.Value.CheckedCount);
+		Assert.Equal(1, result.Value.DownloadedCount);
+		Assert.Equal(0, result.Value.RemainingCount);
+	}
+}

--- a/Application.Tests/Features/ReportTasks/ReportTaskCommandValidatorTests.cs
+++ b/Application.Tests/Features/ReportTasks/ReportTaskCommandValidatorTests.cs
@@ -1,0 +1,163 @@
+using FluentValidation.TestHelper;
+using Moq;
+using RealityScraper.Application.Features.ReportTasks;
+using RealityScraper.Application.Interfaces.Scheduler;
+
+namespace RealityScraper.Application.Tests.Features.ReportTasks;
+
+public class ReportTaskCommandValidatorTests
+{
+	private readonly Mock<IScheduleTimeCalculator> timeCalculatorMock = new();
+
+	private ReportTaskCommandValidator CreateSut(bool cronValid = true)
+	{
+		timeCalculatorMock.Setup(x => x.IsValidExpression(It.IsAny<string>())).Returns(cronValid);
+		return new ReportTaskCommandValidator(timeCalculatorMock.Object);
+	}
+
+	private static TestCommand ValidCommand()
+	{
+		return new TestCommand
+		{
+			Name = "Týdenní přehled vyřazených",
+			CronExpression = "0 6 * * 1",
+			Enabled = true,
+			Recipients = [new ReportTaskRecipientInput("user@example.com")],
+			ScraperTaskIds = [Guid.NewGuid()]
+		};
+	}
+
+	[Fact]
+	public void ValidCommand_PassesValidation()
+	{
+		var sut = CreateSut();
+
+		var result = sut.TestValidate(ValidCommand());
+
+		result.ShouldNotHaveAnyValidationErrors();
+	}
+
+	[Fact]
+	public void EmptyName_FailsValidation()
+	{
+		var sut = CreateSut();
+		var command = ValidCommand() with { Name = string.Empty };
+
+		var result = sut.TestValidate(command);
+
+		result.ShouldHaveValidationErrorFor(x => x.Name);
+	}
+
+	[Fact]
+	public void TooLongName_FailsValidation()
+	{
+		var sut = CreateSut();
+		var command = ValidCommand() with { Name = new string('a', 101) };
+
+		var result = sut.TestValidate(command);
+
+		result.ShouldHaveValidationErrorFor(x => x.Name);
+	}
+
+	[Fact]
+	public void EmptyCron_FailsValidation()
+	{
+		var sut = CreateSut();
+		var command = ValidCommand() with { CronExpression = string.Empty };
+
+		var result = sut.TestValidate(command);
+
+		result.ShouldHaveValidationErrorFor(x => x.CronExpression);
+	}
+
+	[Fact]
+	public void InvalidCron_FailsValidation()
+	{
+		var sut = CreateSut(cronValid: false);
+		var command = ValidCommand() with { CronExpression = "nesmysl" };
+
+		var result = sut.TestValidate(command);
+
+		result.ShouldHaveValidationErrorFor(x => x.CronExpression);
+	}
+
+	[Fact]
+	public void TooLongCron_FailsValidation()
+	{
+		var sut = CreateSut();
+		var command = ValidCommand() with { CronExpression = new string('*', 51) };
+
+		var result = sut.TestValidate(command);
+
+		result.ShouldHaveValidationErrorFor(x => x.CronExpression);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData("neplatny-email")]
+	public void InvalidRecipientEmail_FailsValidation(string email)
+	{
+		var sut = CreateSut();
+		var command = ValidCommand() with { Recipients = [new ReportTaskRecipientInput(email)] };
+
+		var result = sut.TestValidate(command);
+
+		Assert.False(result.IsValid);
+	}
+
+	[Fact]
+	public void TooLongRecipientEmail_FailsValidation()
+	{
+		var sut = CreateSut();
+		var email = new string('a', 95) + "@example.com";
+		var command = ValidCommand() with { Recipients = [new ReportTaskRecipientInput(email)] };
+
+		var result = sut.TestValidate(command);
+
+		Assert.False(result.IsValid);
+	}
+
+	[Fact]
+	public void EmptyScraperTaskId_FailsValidation()
+	{
+		var sut = CreateSut();
+		var command = ValidCommand() with { ScraperTaskIds = [Guid.Empty] };
+
+		var result = sut.TestValidate(command);
+
+		Assert.False(result.IsValid);
+	}
+
+	[Fact]
+	public void NoRecipients_IsAllowed()
+	{
+		// Příjemci nejsou povinní - report může existovat i bez okamžité notifikace.
+		var sut = CreateSut();
+		var command = ValidCommand() with { Recipients = [] };
+
+		var result = sut.TestValidate(command);
+
+		result.ShouldNotHaveAnyValidationErrors();
+	}
+
+	[Fact]
+	public void NoScraperTaskIds_IsAllowed()
+	{
+		// Zdroje lze doplnit později, samotný prázdný seznam validaci neshodí.
+		var sut = CreateSut();
+		var command = ValidCommand() with { ScraperTaskIds = [] };
+
+		var result = sut.TestValidate(command);
+
+		result.ShouldNotHaveAnyValidationErrors();
+	}
+
+	private sealed record TestCommand : IReportTaskCommand
+	{
+		public string Name { get; init; } = string.Empty;
+		public string CronExpression { get; init; } = string.Empty;
+		public bool Enabled { get; init; }
+		public List<ReportTaskRecipientInput> Recipients { get; init; } = [];
+		public List<Guid> ScraperTaskIds { get; init; } = [];
+	}
+}

--- a/Application.Tests/Features/Scheduler/TaskSchedulerServiceTests.cs
+++ b/Application.Tests/Features/Scheduler/TaskSchedulerServiceTests.cs
@@ -1,0 +1,214 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using RealityScraper.Application.Abstractions.Database;
+using RealityScraper.Application.Features.Scheduler;
+using RealityScraper.Application.Interfaces.Repositories.Configuration;
+using RealityScraper.Application.Interfaces.Scheduler;
+using RealityScraper.Domain.Entities.Tasks;
+using RealityScraper.Domain.Enums;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Tests.Features.Scheduler;
+
+public class TaskSchedulerServiceTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+	private static readonly DateTimeOffset CalculatedNextRun = Now.AddHours(6);
+
+	private readonly Mock<ITaskRepository> taskRepositoryMock = new();
+	private readonly Mock<IUnitOfWork> unitOfWorkMock = new();
+	private readonly Mock<IScheduleTimeCalculator> timeCalculatorMock = new();
+	private readonly Mock<IDateTimeProvider> dateTimeProviderMock = new();
+
+	private TaskSchedulerService CreateSut(bool cronValid = true)
+	{
+		dateTimeProviderMock.Setup(x => x.UtcNow).Returns(Now);
+		timeCalculatorMock.Setup(x => x.IsValidExpression(It.IsAny<string>())).Returns(cronValid);
+		timeCalculatorMock
+			.Setup(x => x.GetNextExecutionTime(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
+			.Returns(CalculatedNextRun);
+
+		return new TaskSchedulerService(
+			taskRepositoryMock.Object,
+			unitOfWorkMock.Object,
+			timeCalculatorMock.Object,
+			dateTimeProviderMock.Object,
+			Mock.Of<ILogger<TaskSchedulerService>>());
+	}
+
+	private void SetupActiveTasks(params TaskBase[] tasks)
+	{
+		taskRepositoryMock
+			.Setup(x => x.GetActiveTasksAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(tasks.ToList());
+	}
+
+	private static ScraperTask CreateScraperTask(string cron = "0 6 * * *", DateTimeOffset? nextRunAt = null)
+	{
+		return new ScraperTask("Byty Brno", cron, true, Now.AddDays(-1), nextRunAt);
+	}
+
+	private static RemovedListingsReportTask CreateReportTask(string cron = "0 7 * * 1")
+	{
+		return new RemovedListingsReportTask("Přehled vyřazených", cron, true, Now.AddDays(-1), Now.AddDays(1));
+	}
+
+	[Fact]
+	public async Task LoadActiveTasksAsync_MapsScraperTaskToScraperType()
+	{
+		// Arrange
+		var task = CreateScraperTask(nextRunAt: Now.AddHours(2));
+		task.SetLastRunAt(Now.AddHours(-22));
+		SetupActiveTasks(task);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.LoadActiveTasksAsync(CancellationToken.None);
+
+		// Assert
+		var info = Assert.Single(result);
+		Assert.Equal(task.Id, info.Id);
+		Assert.Equal("Byty Brno", info.Name);
+		Assert.Equal("0 6 * * *", info.CronExpression);
+		Assert.Equal(ScheduledTaskType.Scraper, info.TaskType);
+		Assert.Equal(Now.AddHours(2), info.NextRunTime);
+		Assert.Equal(Now.AddHours(-22), info.LastRunTime);
+		Assert.False(info.IsRunning);
+	}
+
+	[Fact]
+	public async Task LoadActiveTasksAsync_MapsRemovedListingsReportTaskToReportType()
+	{
+		// Arrange
+		SetupActiveTasks(CreateReportTask());
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.LoadActiveTasksAsync(CancellationToken.None);
+
+		// Assert
+		Assert.Equal(ScheduledTaskType.RemovedListingsReport, Assert.Single(result).TaskType);
+	}
+
+	[Fact]
+	public async Task LoadActiveTasksAsync_SkipsTasksWithInvalidCronExpression()
+	{
+		// Arrange
+		// Neplatný cron nesmí shodit načtení ostatních úloh.
+		var invalid = CreateScraperTask("nesmysl");
+		var valid = CreateScraperTask();
+		SetupActiveTasks(invalid, valid);
+		var sut = CreateSut();
+		timeCalculatorMock.Setup(x => x.IsValidExpression("nesmysl")).Returns(false);
+
+		// Act
+		var result = await sut.LoadActiveTasksAsync(CancellationToken.None);
+
+		// Assert
+		Assert.Equal(valid.Id, Assert.Single(result).Id);
+	}
+
+	[Fact]
+	public async Task LoadActiveTasksAsync_CalculatesNextRunTime_WhenTaskHasNone()
+	{
+		// Arrange
+		SetupActiveTasks(CreateScraperTask(nextRunAt: null));
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.LoadActiveTasksAsync(CancellationToken.None);
+
+		// Assert
+		Assert.Equal(CalculatedNextRun, Assert.Single(result).NextRunTime);
+		timeCalculatorMock.Verify(x => x.GetNextExecutionTime("0 6 * * *", Now), Times.Once);
+	}
+
+	[Fact]
+	public async Task LoadActiveTasksAsync_KeepsStoredNextRunTime_WhenTaskHasOne()
+	{
+		// Arrange
+		// Uložený čas má přednost - jinak by "spustit teď" (NextRunAt = teď) přepočet zahodil.
+		var storedNextRun = Now.AddMinutes(-1);
+		SetupActiveTasks(CreateScraperTask(nextRunAt: storedNextRun));
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.LoadActiveTasksAsync(CancellationToken.None);
+
+		// Assert
+		Assert.Equal(storedNextRun, Assert.Single(result).NextRunTime);
+		timeCalculatorMock.Verify(
+			x => x.GetNextExecutionTime(It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task LoadActiveTasksAsync_ReturnsEmptyList_WhenThereAreNoActiveTasks()
+	{
+		// Arrange
+		SetupActiveTasks();
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.LoadActiveTasksAsync(CancellationToken.None);
+
+		// Assert
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public async Task LoadActiveTasksAsync_Throws_ForUnknownTaskType()
+	{
+		// Arrange
+		// Nový potomek TaskBase musí být doplněn do mapování, jinak by se tiše neplánoval.
+		SetupActiveTasks(new UnknownTask("Neznámá", "0 6 * * *", true, Now, null));
+		var sut = CreateSut();
+
+		// Act & Assert
+		await Assert.ThrowsAsync<NotSupportedException>(() => sut.LoadActiveTasksAsync(CancellationToken.None));
+	}
+
+	[Fact]
+	public async Task CalculateNextRunTimeAsync_DelegatesToTimeCalculator()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.CalculateNextRunTimeAsync("0 6 * * *", Now, CancellationToken.None);
+
+		// Assert
+		Assert.Equal(CalculatedNextRun, result);
+		timeCalculatorMock.Verify(x => x.GetNextExecutionTime("0 6 * * *", Now), Times.Once);
+	}
+
+	[Fact]
+	public async Task UpdateTaskExecutionTimesAsync_PersistsResult()
+	{
+		// Arrange
+		var taskId = Guid.NewGuid();
+		var executionResult = new TaskExecutionResult(Now, CalculatedNextRun, "hotovo", true);
+		var sut = CreateSut();
+
+		// Act
+		await sut.UpdateTaskExecutionTimesAsync(taskId, executionResult, CancellationToken.None);
+
+		// Assert
+		taskRepositoryMock.Verify(
+			x => x.UpdateTaskExecutionResultAsync(taskId, executionResult, It.IsAny<CancellationToken>()),
+			Times.Once);
+		unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	private sealed class UnknownTask : TaskBase
+	{
+		public UnknownTask(string name, string cronExpression, bool enabled, DateTimeOffset createdAt, DateTimeOffset? nextRunAt)
+		{
+			Name = name;
+			CronExpression = cronExpression;
+			Enabled = enabled;
+			CreatedAt = createdAt;
+			NextRunAt = nextRunAt;
+		}
+	}
+}

--- a/Application.Tests/Features/ScraperTasks/CreateScraperTaskCommandHandlerTests.cs
+++ b/Application.Tests/Features/ScraperTasks/CreateScraperTaskCommandHandlerTests.cs
@@ -1,0 +1,158 @@
+using Moq;
+using RealityScraper.Application.Abstractions.Database;
+using RealityScraper.Application.Features.ScraperTasks;
+using RealityScraper.Application.Features.ScraperTasks.Create;
+using RealityScraper.Application.Interfaces.Repositories.Configuration;
+using RealityScraper.Application.Interfaces.Scheduler;
+using RealityScraper.Domain.Entities.Tasks;
+using RealityScraper.Domain.Enums;
+using RealityScraper.Domain.Events;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Tests.Features.ScraperTasks;
+
+public class CreateScraperTaskCommandHandlerTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+	private static readonly DateTimeOffset NextRun = Now.AddHours(6);
+
+	private readonly Mock<IScraperTaskRepository> repositoryMock = new();
+	private readonly Mock<IDateTimeProvider> dateTimeProviderMock = new();
+	private readonly Mock<IScheduleTimeCalculator> timeCalculatorMock = new();
+	private readonly Mock<IUnitOfWork> unitOfWorkMock = new();
+
+	private CreateScraperTaskCommandHandler CreateSut()
+	{
+		dateTimeProviderMock.Setup(x => x.UtcNow).Returns(Now);
+		timeCalculatorMock
+			.Setup(x => x.GetNextExecutionTime(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
+			.Returns(NextRun);
+
+		return new CreateScraperTaskCommandHandler(
+			repositoryMock.Object,
+			dateTimeProviderMock.Object,
+			timeCalculatorMock.Object,
+			unitOfWorkMock.Object);
+	}
+
+	private static CreateScraperTaskCommand ValidCommand(bool enabled = true)
+	{
+		return new CreateScraperTaskCommand(
+			"Byty Brno",
+			"0 6 * * *",
+			enabled,
+			[new ScraperTaskRecipientInput("user@example.com")],
+			[new ScraperTaskTargetInput((int)ScrapersEnum.SReality, "https://www.sreality.cz/hledani")]);
+	}
+
+	[Fact]
+	public async Task Handle_CreatesTaskWithRecipientsAndTargets()
+	{
+		// Arrange
+		ScraperTask? added = null;
+		repositoryMock.Setup(x => x.Add(It.IsAny<ScraperTask>())).Callback((ScraperTask t) => added = t);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(ValidCommand(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.NotNull(added);
+		Assert.Equal("Byty Brno", added.Name);
+		Assert.Equal("0 6 * * *", added.CronExpression);
+		Assert.True(added.Enabled);
+		Assert.Equal(Now, added.CreatedAt);
+		Assert.Equal("user@example.com", Assert.Single(added.Recipients).Email);
+		var target = Assert.Single(added.Targets);
+		Assert.Equal(ScrapersEnum.SReality, target.ScraperType);
+		Assert.Equal("https://www.sreality.cz/hledani", target.Url);
+		unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_SchedulesNextRun_WhenTaskIsEnabled()
+	{
+		// Arrange
+		ScraperTask? added = null;
+		repositoryMock.Setup(x => x.Add(It.IsAny<ScraperTask>())).Callback((ScraperTask t) => added = t);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(ValidCommand(enabled: true), CancellationToken.None);
+
+		// Assert
+		Assert.Equal(NextRun, added!.NextRunAt);
+		Assert.Equal(NextRun, result.Value.NextRunAt);
+		timeCalculatorMock.Verify(x => x.GetNextExecutionTime("0 6 * * *", Now), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_DoesNotScheduleNextRun_WhenTaskIsDisabled()
+	{
+		// Arrange
+		// Vypnutá úloha nemá mít naplánovaný běh - jinak by ji scheduler po zapnutí spustil pozdě.
+		ScraperTask? added = null;
+		repositoryMock.Setup(x => x.Add(It.IsAny<ScraperTask>())).Callback((ScraperTask t) => added = t);
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(ValidCommand(enabled: false), CancellationToken.None);
+
+		// Assert
+		Assert.Null(added!.NextRunAt);
+		timeCalculatorMock.Verify(
+			x => x.GetNextExecutionTime(It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_RaisesCreatedEvent()
+	{
+		// Arrange
+		ScraperTask? added = null;
+		repositoryMock.Setup(x => x.Add(It.IsAny<ScraperTask>())).Callback((ScraperTask t) => added = t);
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(ValidCommand(), CancellationToken.None);
+
+		// Assert
+		var domainEvent = Assert.IsType<ScraperTaskCreatedEvent>(Assert.Single(added!.DomainEvents));
+		Assert.Equal(added.Id, domainEvent.ScraperTaskId);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsDetailDtoWithRecipientsAndTargets()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(ValidCommand(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal("Byty Brno", result.Value.Name);
+		Assert.Equal("user@example.com", Assert.Single(result.Value.Recipients).Email);
+		Assert.Equal((int)ScrapersEnum.SReality, Assert.Single(result.Value.Targets).ScraperType);
+	}
+
+	[Fact]
+	public async Task Handle_CreatesTaskWithoutRecipientsOrTargets()
+	{
+		// Arrange
+		ScraperTask? added = null;
+		repositoryMock.Setup(x => x.Add(It.IsAny<ScraperTask>())).Callback((ScraperTask t) => added = t);
+		var sut = CreateSut();
+		var command = ValidCommand() with { Recipients = [], Targets = [] };
+
+		// Act
+		var result = await sut.Handle(command, CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Empty(added!.Recipients);
+		Assert.Empty(added.Targets);
+	}
+}

--- a/Application.Tests/Features/ScraperTasks/UpdateScraperTaskCommandHandlerTests.cs
+++ b/Application.Tests/Features/ScraperTasks/UpdateScraperTaskCommandHandlerTests.cs
@@ -1,0 +1,232 @@
+using Moq;
+using RealityScraper.Application.Abstractions.Database;
+using RealityScraper.Application.Features.ScraperTasks;
+using RealityScraper.Application.Features.ScraperTasks.Update;
+using RealityScraper.Application.Interfaces.Repositories.Configuration;
+using RealityScraper.Application.Interfaces.Scheduler;
+using RealityScraper.Domain.Entities.Tasks;
+using RealityScraper.Domain.Enums;
+using RealityScraper.Domain.Events;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Tests.Features.ScraperTasks;
+
+public class UpdateScraperTaskCommandHandlerTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+	private static readonly DateTimeOffset OriginalNextRun = Now.AddHours(2);
+	private static readonly DateTimeOffset RecalculatedNextRun = Now.AddHours(6);
+
+	private readonly Mock<IScraperTaskRepository> repositoryMock = new();
+	private readonly Mock<IUnitOfWork> unitOfWorkMock = new();
+	private readonly Mock<IScheduleTimeCalculator> timeCalculatorMock = new();
+	private readonly Mock<IDateTimeProvider> dateTimeProviderMock = new();
+
+	private UpdateScraperTaskCommandHandler CreateSut()
+	{
+		dateTimeProviderMock.Setup(x => x.UtcNow).Returns(Now);
+		timeCalculatorMock
+			.Setup(x => x.GetNextExecutionTime(It.IsAny<string>(), It.IsAny<DateTimeOffset>()))
+			.Returns(RecalculatedNextRun);
+
+		return new UpdateScraperTaskCommandHandler(
+			repositoryMock.Object,
+			unitOfWorkMock.Object,
+			timeCalculatorMock.Object,
+			dateTimeProviderMock.Object);
+	}
+
+	private ScraperTask SetupExistingTask(bool enabled = true, string cron = "0 6 * * *")
+	{
+		var task = new ScraperTask("Byty Brno", cron, enabled, Now.AddDays(-7), OriginalNextRun);
+		task.AddRecipient(new ScraperTaskRecipient("old@example.com"));
+		task.AddTarget(new ScraperTaskTarget(ScrapersEnum.SReality, "https://www.sreality.cz/puvodni"));
+
+		repositoryMock
+			.Setup(x => x.GetTaskWithDetailsAsync(task.Id, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(task);
+
+		return task;
+	}
+
+	private static UpdateScraperTaskCommand Command(
+		Guid id,
+		string name = "Byty Brno",
+		string cron = "0 6 * * *",
+		bool enabled = true,
+		List<ScraperTaskRecipientInput>? recipients = null,
+		List<ScraperTaskTargetInput>? targets = null)
+	{
+		return new UpdateScraperTaskCommand(
+			id,
+			name,
+			cron,
+			enabled,
+			recipients ?? [new ScraperTaskRecipientInput("new@example.com")],
+			targets ?? [new ScraperTaskTargetInput((int)ScrapersEnum.RealityIdnes, "https://reality.idnes.cz/nove")]);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsNotFound_WhenTaskDoesNotExist()
+	{
+		// Arrange
+		repositoryMock
+			.Setup(x => x.GetTaskWithDetailsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((ScraperTask?)null);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(Command(Guid.NewGuid()), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsFailure);
+		Assert.Equal("ScraperTask.NotFound", result.Error.Code);
+		unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_UpdatesScalarProperties()
+	{
+		// Arrange
+		var task = SetupExistingTask();
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(Command(task.Id, name: "Domy Brno", cron: "0 8 * * *", enabled: false), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal("Domy Brno", task.Name);
+		Assert.Equal("0 8 * * *", task.CronExpression);
+		Assert.False(task.Enabled);
+		unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReplacesRecipientsAndTargets()
+	{
+		// Arrange
+		var task = SetupExistingTask();
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(Command(task.Id), CancellationToken.None);
+
+		// Assert
+		Assert.Equal("new@example.com", Assert.Single(task.Recipients).Email);
+		var target = Assert.Single(task.Targets);
+		Assert.Equal(ScrapersEnum.RealityIdnes, target.ScraperType);
+		Assert.Equal("https://reality.idnes.cz/nove", target.Url);
+	}
+
+	[Fact]
+	public async Task Handle_ClearsRecipientsAndTargets_WhenCommandHasNone()
+	{
+		// Arrange
+		var task = SetupExistingTask();
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(Command(task.Id, recipients: [], targets: []), CancellationToken.None);
+
+		// Assert
+		Assert.Empty(task.Recipients);
+		Assert.Empty(task.Targets);
+	}
+
+	[Fact]
+	public async Task Handle_KeepsNextRunAt_WhenNeitherCronNorEnabledChanged()
+	{
+		// Arrange
+		// Přepočet by posunul nejbližší běh - přejmenování úlohy nesmí zdržet už naplánovaný scrap.
+		var task = SetupExistingTask(enabled: true, cron: "0 6 * * *");
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(Command(task.Id, name: "Jiný název", cron: "0 6 * * *", enabled: true), CancellationToken.None);
+
+		// Assert
+		Assert.Equal(OriginalNextRun, task.NextRunAt);
+		timeCalculatorMock.Verify(
+			x => x.GetNextExecutionTime(It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_RecalculatesNextRunAt_WhenCronChanged()
+	{
+		// Arrange
+		var task = SetupExistingTask(cron: "0 6 * * *");
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(Command(task.Id, cron: "0 18 * * *"), CancellationToken.None);
+
+		// Assert
+		Assert.Equal(RecalculatedNextRun, task.NextRunAt);
+		timeCalculatorMock.Verify(x => x.GetNextExecutionTime("0 18 * * *", Now), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ClearsNextRunAt_WhenTaskGetsDisabled()
+	{
+		// Arrange
+		var task = SetupExistingTask(enabled: true);
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(Command(task.Id, enabled: false), CancellationToken.None);
+
+		// Assert
+		Assert.Null(task.NextRunAt);
+		timeCalculatorMock.Verify(
+			x => x.GetNextExecutionTime(It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task Handle_SchedulesNextRunAt_WhenTaskGetsEnabled()
+	{
+		// Arrange
+		var task = SetupExistingTask(enabled: false);
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(Command(task.Id, enabled: true), CancellationToken.None);
+
+		// Assert
+		Assert.Equal(RecalculatedNextRun, task.NextRunAt);
+	}
+
+	[Fact]
+	public async Task Handle_RaisesUpdatedEvent()
+	{
+		// Arrange
+		var task = SetupExistingTask();
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(Command(task.Id), CancellationToken.None);
+
+		// Assert
+		var domainEvent = Assert.IsType<ScraperTaskUpdatedEvent>(Assert.Single(task.DomainEvents));
+		Assert.Equal(task.Id, domainEvent.ScraperTaskId);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsDetailDtoWithReplacedCollections()
+	{
+		// Arrange
+		var task = SetupExistingTask();
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(Command(task.Id), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(task.Id, result.Value.Id);
+		Assert.Equal("new@example.com", Assert.Single(result.Value.Recipients).Email);
+		Assert.Equal("https://reality.idnes.cz/nove", Assert.Single(result.Value.Targets).Url);
+	}
+}

--- a/Application.Tests/Features/Scraping/ListingChangeProcessorTests.cs
+++ b/Application.Tests/Features/Scraping/ListingChangeProcessorTests.cs
@@ -1,0 +1,265 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using RealityScraper.Application.Features.Scraping;
+using RealityScraper.Application.Features.Scraping.Model.Report;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.Domain.Entities.Realty;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Tests.Features.Scraping;
+
+public class ListingChangeProcessorTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+	private static readonly DateTimeOffset Earlier = Now.AddDays(-10);
+	private static readonly Guid TaskId = Guid.NewGuid();
+
+	private readonly Mock<IListingRepository> listingRepositoryMock = new();
+	private readonly Mock<IDateTimeProvider> dateTimeProviderMock = new();
+
+	private ListingChangeProcessor CreateSut()
+	{
+		dateTimeProviderMock.Setup(x => x.UtcNow).Returns(Now);
+		return new ListingChangeProcessor(
+			listingRepositoryMock.Object,
+			dateTimeProviderMock.Object,
+			Mock.Of<ILogger<ListingChangeProcessor>>());
+	}
+
+	private static ListingItem NewItem(string externalId, decimal? price = 5_000_000)
+	{
+		return new ListingItem
+		{
+			Title = $"Prodej domu {externalId}",
+			Price = price,
+			Location = "Brno",
+			Url = $"https://example.com/{externalId}",
+			ImageUrl = $"https://example.com/{externalId}.jpg",
+			ExternalId = externalId
+		};
+	}
+
+	private static ListingItemWithNewPrice PriceChangedItem(string externalId, decimal? newPrice, decimal? oldPrice)
+	{
+		return new ListingItemWithNewPrice
+		{
+			Title = $"Prodej domu {externalId}",
+			Price = newPrice,
+			OldPrice = oldPrice,
+			Location = "Brno",
+			Url = $"https://example.com/{externalId}",
+			ImageUrl = $"https://example.com/{externalId}.jpg",
+			ExternalId = externalId
+		};
+	}
+
+	private static Listing ExistingListing(string externalId, decimal? price)
+	{
+		return new Listing
+		{
+			Id = Guid.NewGuid(),
+			ExternalId = externalId,
+			Title = "Prodej domu",
+			Location = "Brno",
+			Url = $"https://example.com/{externalId}",
+			ImageUrl = string.Empty,
+			Price = price,
+			CreatedAt = Earlier,
+			LastSeenAt = Earlier,
+			PriceFrom = Earlier,
+			ScraperTaskId = TaskId
+		};
+	}
+
+	private static ScrapingReport CreateReport(params PortalReport[] results)
+	{
+		return new ScrapingReport
+		{
+			ScraperTaskId = TaskId,
+			TaskName = "task",
+			ReportDate = Now,
+			ScrapingSucceeded = true,
+			Results = results.ToList()
+		};
+	}
+
+	private static PortalReport Portal(
+		string siteName = "sreality",
+		List<ListingItem>? newListings = null,
+		List<ListingItemWithNewPrice>? priceChanged = null)
+	{
+		return new PortalReport
+		{
+			SiteName = siteName,
+			NewListings = newListings ?? [],
+			PriceChangedListings = priceChanged ?? []
+		};
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_AddsNewListingsToRepositoryAndReturnsThemForDownload()
+	{
+		// Arrange
+		var report = CreateReport(Portal(newListings: [NewItem("ext-1", 4_200_000)]));
+		var added = new List<Listing>();
+		listingRepositoryMock.Setup(x => x.Add(It.IsAny<Listing>())).Callback((Listing l) => added.Add(l));
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		var listing = Assert.Single(added);
+		Assert.Equal("ext-1", listing.ExternalId);
+		Assert.Equal("Prodej domu ext-1", listing.Title);
+		Assert.Equal(4_200_000, listing.Price);
+		Assert.Equal("Brno", listing.Location);
+		Assert.Equal("https://example.com/ext-1", listing.Url);
+		Assert.Equal("https://example.com/ext-1.jpg", listing.ImageUrl);
+		Assert.Equal(TaskId, listing.ScraperTaskId);
+		Assert.Equal(Now, listing.CreatedAt);
+		Assert.Equal(Now, listing.LastSeenAt);
+		Assert.Equal(Now, listing.PriceFrom);
+		Assert.Same(listing, Assert.Single(toDownload));
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_AddsNewListingsFromAllPortals()
+	{
+		// Arrange
+		var report = CreateReport(
+			Portal("sreality", newListings: [NewItem("s-1"), NewItem("s-2")]),
+			Portal("reality.idnes", newListings: [NewItem("i-1")]));
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal(["s-1", "s-2", "i-1"], toDownload.Select(l => l.ExternalId));
+		listingRepositoryMock.Verify(x => x.Add(It.IsAny<Listing>()), Times.Exactly(3));
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_DoesNotLoadExistingListings_WhenThereAreNoPriceChanges()
+	{
+		// Arrange
+		// Dotaz do DB má smysl jen kvůli cenovým změnám - u samotných nových inzerátů je zbytečný.
+		var report = CreateReport(Portal(newListings: [NewItem("ext-1")]));
+		var sut = CreateSut();
+
+		// Act
+		await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		listingRepositoryMock.Verify(
+			x => x.GetByScraperTaskIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_WritesPreviousPriceToHistoryAndUpdatesCurrentPrice()
+	{
+		// Arrange
+		var existing = ExistingListing("ext-1", 5_000_000);
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport(Portal(priceChanged: [PriceChangedItem("ext-1", 4_500_000, 5_000_000)]));
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		var history = Assert.Single(existing.PriceHistories);
+		Assert.Equal(5_000_000, history.Price);
+		Assert.Equal(Earlier, history.RecordedAt);
+		Assert.Equal(4_500_000, existing.Price);
+		Assert.Equal(Now, existing.PriceFrom);
+		Assert.Equal(Now, existing.LastSeenAt);
+
+		// Cenová změna nemění obrázek, takže se nestahuje znovu.
+		Assert.Empty(toDownload);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_SkipsPriceChange_WhenListingIsNotInDatabase()
+	{
+		// Arrange
+		var other = ExistingListing("ext-other", 1_000_000);
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([other]);
+		var report = CreateReport(Portal(priceChanged: [PriceChangedItem("ext-missing", 4_500_000, 5_000_000)]));
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Empty(toDownload);
+		Assert.Empty(other.PriceHistories);
+		Assert.Equal(1_000_000, other.Price);
+		Assert.Equal(Earlier, other.LastSeenAt);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_HandlesNewListingsAndPriceChangesTogether()
+	{
+		// Arrange
+		var existing = ExistingListing("ext-old", 3_000_000);
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport(Portal(
+			newListings: [NewItem("ext-new")],
+			priceChanged: [PriceChangedItem("ext-old", 2_800_000, 3_000_000)]));
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal("ext-new", Assert.Single(toDownload).ExternalId);
+		Assert.Equal(2_800_000, existing.Price);
+		Assert.Equal(3_000_000, Assert.Single(existing.PriceHistories).Price);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_KeepsOlderHistoryEntries()
+	{
+		// Arrange
+		var existing = ExistingListing("ext-1", 5_000_000);
+		existing.PriceHistories.Add(new PriceHistory { Price = 5_500_000, RecordedAt = Earlier.AddDays(-20) });
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport(Portal(priceChanged: [PriceChangedItem("ext-1", 4_500_000, 5_000_000)]));
+		var sut = CreateSut();
+
+		// Act
+		await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal([5_500_000, 5_000_000], existing.PriceHistories.Select(h => h.Price));
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_ReturnsEmptyList_WhenReportHasNoChanges()
+	{
+		// Arrange
+		var report = CreateReport(Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Empty(toDownload);
+		listingRepositoryMock.Verify(x => x.Add(It.IsAny<Listing>()), Times.Never);
+		listingRepositoryMock.Verify(
+			x => x.GetByScraperTaskIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+}

--- a/Application.Tests/Features/Scraping/ListingImageDownloaderTests.cs
+++ b/Application.Tests/Features/Scraping/ListingImageDownloaderTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using RealityScraper.Application.Features.Scraping;
+using RealityScraper.Application.Interfaces.Scraping;
+using RealityScraper.Domain.Entities.Realty;
+
+namespace RealityScraper.Application.Tests.Features.Scraping;
+
+public class ListingImageDownloaderTests
+{
+	private readonly Mock<IImageDownloadService> imageDownloadServiceMock = new();
+
+	private ListingImageDownloader CreateSut()
+	{
+		return new ListingImageDownloader(
+			imageDownloadServiceMock.Object,
+			Mock.Of<ILogger<ListingImageDownloader>>());
+	}
+
+	private static Listing CreateListing(string externalId)
+	{
+		return new Listing
+		{
+			Id = Guid.NewGuid(),
+			ExternalId = externalId,
+			Title = "Prodej domu",
+			Location = "Brno",
+			Url = $"https://example.com/{externalId}",
+			ImageUrl = $"https://example.com/{externalId}.jpg"
+		};
+	}
+
+	[Fact]
+	public async Task DownloadImagesAsync_DoesNothing_ForEmptyList()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		await sut.DownloadImagesAsync([], CancellationToken.None);
+
+		// Assert
+		imageDownloadServiceMock.Verify(
+			x => x.DownloadImageAsync(It.IsAny<Listing>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task DownloadImagesAsync_DownloadsEveryListing()
+	{
+		// Arrange
+		var listings = new List<Listing> { CreateListing("ext-1"), CreateListing("ext-2") };
+		var sut = CreateSut();
+
+		// Act
+		await sut.DownloadImagesAsync(listings, CancellationToken.None);
+
+		// Assert
+		foreach (var listing in listings)
+		{
+			imageDownloadServiceMock.Verify(x => x.DownloadImageAsync(listing, It.IsAny<CancellationToken>()), Times.Once);
+		}
+	}
+
+	[Fact]
+	public async Task DownloadImagesAsync_ContinuesWithRemainingListings_WhenOneDownloadFails()
+	{
+		// Arrange
+		// Neúspěšné stažení obrázku nesmí shodit celý běh - report je už uložený.
+		var failing = CreateListing("ext-1");
+		var succeeding = CreateListing("ext-2");
+		imageDownloadServiceMock
+			.Setup(x => x.DownloadImageAsync(failing, It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new HttpRequestException("boom"));
+		var sut = CreateSut();
+
+		// Act
+		await sut.DownloadImagesAsync([failing, succeeding], CancellationToken.None);
+
+		// Assert
+		imageDownloadServiceMock.Verify(x => x.DownloadImageAsync(succeeding, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task DownloadImagesAsync_PropagatesCancellation()
+	{
+		// Arrange
+		var listings = new List<Listing> { CreateListing("ext-1"), CreateListing("ext-2") };
+		imageDownloadServiceMock
+			.Setup(x => x.DownloadImageAsync(It.IsAny<Listing>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new OperationCanceledException());
+		var sut = CreateSut();
+
+		// Act & Assert
+		await Assert.ThrowsAsync<OperationCanceledException>(
+			() => sut.DownloadImagesAsync(listings, CancellationToken.None));
+
+		imageDownloadServiceMock.Verify(
+			x => x.DownloadImageAsync(It.IsAny<Listing>(), It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+}

--- a/Application.Tests/Features/Scraping/ListingNotificationServiceTests.cs
+++ b/Application.Tests/Features/Scraping/ListingNotificationServiceTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using RealityScraper.Application.Features.Scraping;
+using RealityScraper.Application.Features.Scraping.Model.Report;
+using RealityScraper.Application.Interfaces.Mailing;
+
+namespace RealityScraper.Application.Tests.Features.Scraping;
+
+public class ListingNotificationServiceTests
+{
+	private static readonly List<string> Recipients = ["user@example.com"];
+
+	private readonly Mock<IMailerService> mailerServiceMock = new();
+
+	private ListingNotificationService CreateSut()
+	{
+		return new ListingNotificationService(
+			mailerServiceMock.Object,
+			Mock.Of<ILogger<ListingNotificationService>>());
+	}
+
+	private static ListingItem NewItem(string externalId = "ext-1")
+	{
+		return new ListingItem
+		{
+			Title = "Prodej domu",
+			Price = 5_000_000,
+			Location = "Brno",
+			Url = "https://example.com/1",
+			ImageUrl = "https://example.com/1.jpg",
+			ExternalId = externalId
+		};
+	}
+
+	private static ListingItemWithNewPrice PriceChangedItem(string externalId = "ext-2")
+	{
+		return new ListingItemWithNewPrice
+		{
+			Title = "Prodej bytu",
+			Price = 4_500_000,
+			OldPrice = 5_000_000,
+			Location = "Brno",
+			Url = "https://example.com/2",
+			ImageUrl = "https://example.com/2.jpg",
+			ExternalId = externalId
+		};
+	}
+
+	private static ScrapingReport CreateReport(
+		List<ListingItem>? newListings = null,
+		List<ListingItemWithNewPrice>? priceChanged = null)
+	{
+		return new ScrapingReport
+		{
+			ScraperTaskId = Guid.NewGuid(),
+			TaskName = "Byty Brno",
+			ScrapingSucceeded = true,
+			Results =
+			[
+				new PortalReport
+				{
+					SiteName = "sreality",
+					NewListings = newListings ?? [],
+					PriceChangedListings = priceChanged ?? []
+				}
+			]
+		};
+	}
+
+	[Fact]
+	public async Task SendNotificationsAsync_DoesNotSendMail_WhenThereAreNoChanges()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		await sut.SendNotificationsAsync(CreateReport(), Recipients, CancellationToken.None);
+
+		// Assert
+		mailerServiceMock.Verify(
+			x => x.SendListingReportAsync(It.IsAny<ScrapingReport>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task SendNotificationsAsync_SendsMail_WhenThereAreNewListings()
+	{
+		// Arrange
+		var report = CreateReport(newListings: [NewItem()]);
+		mailerServiceMock
+			.Setup(x => x.SendListingReportAsync(report, Recipients, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+		var sut = CreateSut();
+
+		// Act
+		await sut.SendNotificationsAsync(report, Recipients, CancellationToken.None);
+
+		// Assert
+		mailerServiceMock.Verify(
+			x => x.SendListingReportAsync(report, Recipients, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task SendNotificationsAsync_SendsMail_WhenOnlyPricesChanged()
+	{
+		// Arrange
+		var report = CreateReport(priceChanged: [PriceChangedItem()]);
+		mailerServiceMock
+			.Setup(x => x.SendListingReportAsync(report, Recipients, It.IsAny<CancellationToken>()))
+			.ReturnsAsync(true);
+		var sut = CreateSut();
+
+		// Act
+		await sut.SendNotificationsAsync(report, Recipients, CancellationToken.None);
+
+		// Assert
+		mailerServiceMock.Verify(
+			x => x.SendListingReportAsync(report, Recipients, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task SendNotificationsAsync_Throws_WhenMailWasNotSent()
+	{
+		// Arrange
+		// Výjimka je záměr - zabrání uložení inzerátů jako viděných, takže další běh notifikaci zopakuje.
+		var report = CreateReport(newListings: [NewItem()]);
+		mailerServiceMock
+			.Setup(x => x.SendListingReportAsync(It.IsAny<ScrapingReport>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(false);
+		var sut = CreateSut();
+
+		// Act & Assert
+		var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => sut.SendNotificationsAsync(report, Recipients, CancellationToken.None));
+		Assert.Contains("Byty Brno", exception.Message);
+	}
+}

--- a/Application.Tests/Features/Scraping/ScrapingReportProcessorTests.cs
+++ b/Application.Tests/Features/Scraping/ScrapingReportProcessorTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using RealityScraper.Application.Abstractions.Database;
+using RealityScraper.Application.Features.Scraping;
+using RealityScraper.Application.Features.Scraping.Model.Report;
+using RealityScraper.Domain.Entities.Realty;
+
+namespace RealityScraper.Application.Tests.Features.Scraping;
+
+public class ScrapingReportProcessorTests
+{
+	private readonly Mock<IListingChangeProcessor> changeProcessorMock = new();
+	private readonly Mock<IRemovedListingDetector> removedDetectorMock = new();
+	private readonly Mock<IListingNotificationService> notificationServiceMock = new();
+	private readonly Mock<IListingImageDownloader> imageDownloaderMock = new();
+	private readonly Mock<IUnitOfWork> unitOfWorkMock = new();
+
+	private readonly List<string> steps = new();
+
+	private static readonly ScrapingReport Report = new()
+	{
+		ScraperTaskId = Guid.NewGuid(),
+		TaskName = "task",
+		ScrapingSucceeded = true
+	};
+
+	private static readonly List<string> Recipients = ["user@example.com"];
+
+	private ScrapingReportProcessor CreateSut()
+	{
+		return new ScrapingReportProcessor(
+			changeProcessorMock.Object,
+			removedDetectorMock.Object,
+			notificationServiceMock.Object,
+			imageDownloaderMock.Object,
+			unitOfWorkMock.Object,
+			Mock.Of<ILogger<ScrapingReportProcessor>>());
+	}
+
+	/// <summary>
+	/// Zaznamená pořadí, ve kterém procesor volá jednotlivé kroky.
+	/// </summary>
+	private void RecordStepOrder(List<Listing>? listingsToDownload = null)
+	{
+		changeProcessorMock
+			.Setup(x => x.ProcessChangesAsync(It.IsAny<ScrapingReport>(), It.IsAny<CancellationToken>()))
+			.Callback(() => steps.Add("changes"))
+			.ReturnsAsync(listingsToDownload ?? []);
+
+		removedDetectorMock
+			.Setup(x => x.DetectAsync(It.IsAny<ScrapingReport>(), It.IsAny<CancellationToken>()))
+			.Callback(() => steps.Add("removed"))
+			.Returns(Task.CompletedTask);
+
+		notificationServiceMock
+			.Setup(x => x.SendNotificationsAsync(It.IsAny<ScrapingReport>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+			.Callback(() => steps.Add("notify"))
+			.Returns(Task.CompletedTask);
+
+		unitOfWorkMock
+			.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+			.Callback(() => steps.Add("save"))
+			.Returns(Task.CompletedTask);
+
+		imageDownloaderMock
+			.Setup(x => x.DownloadImagesAsync(It.IsAny<List<Listing>>(), It.IsAny<CancellationToken>()))
+			.Callback(() => steps.Add("images"))
+			.Returns(Task.CompletedTask);
+	}
+
+	[Fact]
+	public async Task ProcessReportAsync_RunsStepsInOrder_WithImagesDownloadedAfterSave()
+	{
+		// Arrange
+		// Obrázky se smí stahovat až po uložení - do té doby nemají inzeráty přidělené Id.
+		RecordStepOrder();
+		var sut = CreateSut();
+
+		// Act
+		await sut.ProcessReportAsync(Report, Recipients, CancellationToken.None);
+
+		// Assert
+		Assert.Equal(["changes", "removed", "notify", "save", "images"], steps);
+	}
+
+	[Fact]
+	public async Task ProcessReportAsync_PassesNewListingsToImageDownloader()
+	{
+		// Arrange
+		var toDownload = new List<Listing> { new() { ExternalId = "ext-1", Title = "t", Location = "l", Url = "u", ImageUrl = "i" } };
+		RecordStepOrder(toDownload);
+		var sut = CreateSut();
+
+		// Act
+		await sut.ProcessReportAsync(Report, Recipients, CancellationToken.None);
+
+		// Assert
+		imageDownloaderMock.Verify(x => x.DownloadImagesAsync(toDownload, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task ProcessReportAsync_ForwardsRecipientsToNotificationService()
+	{
+		// Arrange
+		RecordStepOrder();
+		var sut = CreateSut();
+
+		// Act
+		await sut.ProcessReportAsync(Report, Recipients, CancellationToken.None);
+
+		// Assert
+		notificationServiceMock.Verify(
+			x => x.SendNotificationsAsync(Report, Recipients, It.IsAny<CancellationToken>()),
+			Times.Once);
+	}
+
+	[Fact]
+	public async Task ProcessReportAsync_DoesNotSaveOrDownload_WhenNotificationFails()
+	{
+		// Arrange
+		// Neuložení je záměr: další běh notifikaci zopakuje, protože inzeráty nejsou označené jako viděné.
+		RecordStepOrder();
+		notificationServiceMock
+			.Setup(x => x.SendNotificationsAsync(It.IsAny<ScrapingReport>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("odeslání selhalo"));
+		var sut = CreateSut();
+
+		// Act & Assert
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => sut.ProcessReportAsync(Report, Recipients, CancellationToken.None));
+
+		unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+		imageDownloaderMock.Verify(
+			x => x.DownloadImagesAsync(It.IsAny<List<Listing>>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+	}
+
+	[Fact]
+	public async Task ProcessReportAsync_DoesNotNotify_WhenRemovedDetectionFails()
+	{
+		// Arrange
+		RecordStepOrder();
+		removedDetectorMock
+			.Setup(x => x.DetectAsync(It.IsAny<ScrapingReport>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("detekce selhala"));
+		var sut = CreateSut();
+
+		// Act & Assert
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => sut.ProcessReportAsync(Report, Recipients, CancellationToken.None));
+
+		notificationServiceMock.Verify(
+			x => x.SendNotificationsAsync(It.IsAny<ScrapingReport>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()),
+			Times.Never);
+		unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+	}
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />

--- a/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/Infrastructure.Tests/Logging/TaskLogStoreTests.cs
+++ b/Infrastructure.Tests/Logging/TaskLogStoreTests.cs
@@ -1,0 +1,190 @@
+using RealityScraper.Infrastructure.Logging;
+
+namespace RealityScraper.Infrastructure.Tests.Logging;
+
+public class TaskLogStoreTests
+{
+	// Musí odpovídat MaxLines v TaskLogStore.
+	private const int MaxLines = 1000;
+
+	[Fact]
+	public void GetAndClear_ReturnsNull_WhenCaptureWasNeverStarted()
+	{
+		// Arrange
+		var sut = new TaskLogStore();
+
+		// Act
+		var result = sut.GetAndClear(Guid.NewGuid());
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void Append_IsIgnored_WhenCaptureWasNotStarted()
+	{
+		// Arrange
+		// Logy z úloh, které nesbíráme, nesmí nekontrolovaně růst v paměti.
+		var sut = new TaskLogStore();
+		var taskId = Guid.NewGuid();
+
+		// Act
+		sut.Append(taskId, "řádek mimo záznam");
+
+		// Assert
+		Assert.Null(sut.GetAndClear(taskId));
+	}
+
+	[Fact]
+	public void GetAndClear_ReturnsAppendedLinesInOrder()
+	{
+		// Arrange
+		var sut = new TaskLogStore();
+		var taskId = Guid.NewGuid();
+		sut.StartCapture(taskId);
+
+		// Act
+		sut.Append(taskId, "první");
+		sut.Append(taskId, "druhý");
+
+		// Assert
+		Assert.Equal($"první{Environment.NewLine}druhý", sut.GetAndClear(taskId));
+	}
+
+	[Fact]
+	public void GetAndClear_ReturnsEmptyString_WhenNothingWasAppended()
+	{
+		// Arrange
+		var sut = new TaskLogStore();
+		var taskId = Guid.NewGuid();
+		sut.StartCapture(taskId);
+
+		// Act
+		var result = sut.GetAndClear(taskId);
+
+		// Assert
+		Assert.Equal(string.Empty, result);
+	}
+
+	[Fact]
+	public void GetAndClear_RemovesTheCapture()
+	{
+		// Arrange
+		// Log se vyzvedává jednou (po doběhnutí úlohy) a nesmí zůstat viset v paměti.
+		var sut = new TaskLogStore();
+		var taskId = Guid.NewGuid();
+		sut.StartCapture(taskId);
+		sut.Append(taskId, "řádek");
+
+		// Act
+		var first = sut.GetAndClear(taskId);
+		var second = sut.GetAndClear(taskId);
+
+		// Assert
+		Assert.Equal("řádek", first);
+		Assert.Null(second);
+	}
+
+	[Fact]
+	public void StartCapture_DiscardsPreviousContentForTheSameTask()
+	{
+		// Arrange
+		var sut = new TaskLogStore();
+		var taskId = Guid.NewGuid();
+		sut.StartCapture(taskId);
+		sut.Append(taskId, "z předchozího běhu");
+
+		// Act
+		sut.StartCapture(taskId);
+		sut.Append(taskId, "z aktuálního běhu");
+
+		// Assert
+		Assert.Equal("z aktuálního běhu", sut.GetAndClear(taskId));
+	}
+
+	[Fact]
+	public void Capture_KeepsTasksIsolated()
+	{
+		// Arrange
+		var sut = new TaskLogStore();
+		var firstTaskId = Guid.NewGuid();
+		var secondTaskId = Guid.NewGuid();
+		sut.StartCapture(firstTaskId);
+		sut.StartCapture(secondTaskId);
+
+		// Act
+		sut.Append(firstTaskId, "první úloha");
+		sut.Append(secondTaskId, "druhá úloha");
+
+		// Assert
+		Assert.Equal("první úloha", sut.GetAndClear(firstTaskId));
+		Assert.Equal("druhá úloha", sut.GetAndClear(secondTaskId));
+	}
+
+	[Fact]
+	public void Append_TruncatesAfterMaxLines()
+	{
+		// Arrange
+		var sut = new TaskLogStore();
+		var taskId = Guid.NewGuid();
+		sut.StartCapture(taskId);
+
+		// Act
+		for (var i = 0; i < MaxLines + 50; i++)
+		{
+			sut.Append(taskId, $"řádek {i}");
+		}
+
+		// Assert
+		var result = sut.GetAndClear(taskId);
+		Assert.NotNull(result);
+		var lines = result.Split(Environment.NewLine);
+		Assert.Equal(MaxLines + 1, lines.Length);
+		Assert.Contains("zkrácen", lines[^1]);
+		Assert.DoesNotContain($"řádek {MaxLines}", result);
+	}
+
+	[Fact]
+	public void Append_WritesTruncationNoticeOnlyOnce()
+	{
+		// Arrange
+		var sut = new TaskLogStore();
+		var taskId = Guid.NewGuid();
+		sut.StartCapture(taskId);
+
+		// Act
+		for (var i = 0; i < MaxLines + 500; i++)
+		{
+			sut.Append(taskId, $"řádek {i}");
+		}
+
+		// Assert
+		var result = sut.GetAndClear(taskId);
+		Assert.NotNull(result);
+		var noticeCount = result.Split(Environment.NewLine).Count(l => l.Contains("zkrácen"));
+		Assert.Equal(1, noticeCount);
+	}
+
+	[Fact]
+	public void Append_TruncatesWhenTotalSizeExceedsLimit()
+	{
+		// Arrange
+		// Málo, ale velmi dlouhých řádků nesmí obejít limit na počet řádků.
+		var sut = new TaskLogStore();
+		var taskId = Guid.NewGuid();
+		sut.StartCapture(taskId);
+		var longLine = new string('x', 64 * 1024);
+
+		// Act
+		for (var i = 0; i < 20; i++)
+		{
+			sut.Append(taskId, longLine);
+		}
+
+		// Assert
+		var result = sut.GetAndClear(taskId);
+		Assert.NotNull(result);
+		Assert.Contains("zkrácen", result);
+		Assert.True(result.Length < 20 * longLine.Length);
+	}
+}

--- a/Infrastructure.Tests/Utilities/ListingImagePathResolverTests.cs
+++ b/Infrastructure.Tests/Utilities/ListingImagePathResolverTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Configuration;
+using RealityScraper.Infrastructure.Utilities;
+
+namespace RealityScraper.Infrastructure.Tests.Utilities;
+
+public class ListingImagePathResolverTests
+{
+	private static ListingImagePathResolver CreateSut(string? imagePath)
+	{
+		var settings = new Dictionary<string, string?>();
+		if (imagePath != null)
+		{
+			settings["FileStorage:ImagePath"] = imagePath;
+		}
+
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(settings)
+			.Build();
+
+		return new ListingImagePathResolver(configuration);
+	}
+
+	[Fact]
+	public void GetImageFolderPath_ShardsByFirstTwoCharactersOfId()
+	{
+		// Arrange
+		// Rozdělení do podsložek drží počet souborů v jedné složce rozumný.
+		var listingId = new Guid("ab123456-0000-0000-0000-000000000000");
+		var sut = CreateSut("files/images");
+
+		// Act
+		var folder = sut.GetImageFolderPath(listingId);
+
+		// Assert
+		Assert.Equal("ab", Path.GetFileName(folder));
+	}
+
+	[Fact]
+	public void GetImageFilePath_IsFolderPathPlusIdWithJpgExtension()
+	{
+		// Arrange
+		var listingId = Guid.NewGuid();
+		var sut = CreateSut("files/images");
+
+		// Act
+		var filePath = sut.GetImageFilePath(listingId);
+
+		// Assert
+		// Porovnává se přes GetFullPath - resolver nechává oddělovače z konfigurace tak, jak jsou.
+		Assert.Equal(
+			Path.GetFullPath(sut.GetImageFolderPath(listingId)),
+			Path.GetFullPath(Path.GetDirectoryName(filePath)!));
+		Assert.Equal($"{listingId}.jpg", Path.GetFileName(filePath));
+	}
+
+	[Fact]
+	public void GetImageFolderPath_UsesConfiguredRoot()
+	{
+		// Arrange
+		var listingId = Guid.NewGuid();
+		var sut = CreateSut("custom/storage");
+
+		// Act
+		var folder = sut.GetImageFolderPath(listingId);
+
+		// Assert
+		var expected = Path.Combine(Directory.GetCurrentDirectory(), "custom/storage", listingId.ToString()[..2]);
+		Assert.Equal(expected, folder);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void GetImageFolderPath_FallsBackToDefaultRoot_WhenNotConfigured(string? configuredPath)
+	{
+		// Arrange
+		var listingId = Guid.NewGuid();
+		var sut = CreateSut(configuredPath);
+
+		// Act
+		var folder = sut.GetImageFolderPath(listingId);
+
+		// Assert
+		var expected = Path.Combine(Directory.GetCurrentDirectory(), "files/images", listingId.ToString()[..2]);
+		Assert.Equal(expected, folder);
+	}
+
+	[Fact]
+	public void GetImageFolderPath_HonoursAbsoluteConfiguredRoot()
+	{
+		// Arrange
+		// Kontejner mapuje úložiště na absolutní cestu k volume.
+		var listingId = Guid.NewGuid();
+		var root = Path.Combine(Path.GetTempPath(), "reality-scraper-images");
+		var sut = CreateSut(root);
+
+		// Act
+		var folder = sut.GetImageFolderPath(listingId);
+
+		// Assert
+		Assert.Equal(Path.Combine(root, listingId.ToString()[..2]), folder);
+	}
+
+	[Fact]
+	public void GetImageFilePath_IsStableForTheSameListing()
+	{
+		// Arrange
+		// Stahování, čtení i doplňování náhledů musí sáhnout na tentýž soubor.
+		var listingId = Guid.NewGuid();
+		var sut = CreateSut("files/images");
+
+		// Act & Assert
+		Assert.Equal(sut.GetImageFilePath(listingId), sut.GetImageFilePath(listingId));
+	}
+}

--- a/Infrastructure.Tests/Utilities/ListingImageReaderTests.cs
+++ b/Infrastructure.Tests/Utilities/ListingImageReaderTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using RealityScraper.Infrastructure.Utilities;
+
+namespace RealityScraper.Infrastructure.Tests.Utilities;
+
+/// <summary>
+/// Čtení jede proti skutečnému disku - kontroluje se tím i to, že reader a resolver
+/// míří na stejný soubor.
+/// </summary>
+public sealed class ListingImageReaderTests : IDisposable
+{
+	private readonly string root = Path.Combine(Path.GetTempPath(), $"reality-scraper-tests-{Guid.NewGuid()}");
+	private readonly ListingImagePathResolver pathResolver;
+	private readonly ListingImageReader sut;
+
+	public ListingImageReaderTests()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?> { ["FileStorage:ImagePath"] = root })
+			.Build();
+
+		pathResolver = new ListingImagePathResolver(configuration);
+		sut = new ListingImageReader(pathResolver, NullLogger<ListingImageReader>.Instance);
+	}
+
+	public void Dispose()
+	{
+		if (Directory.Exists(root))
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	private void WriteImage(Guid listingId, byte[] content)
+	{
+		Directory.CreateDirectory(pathResolver.GetImageFolderPath(listingId));
+		File.WriteAllBytes(pathResolver.GetImageFilePath(listingId), content);
+	}
+
+	[Fact]
+	public void ImageExists_ReturnsFalse_WhenImageWasNotDownloaded()
+	{
+		Assert.False(sut.ImageExists(Guid.NewGuid()));
+	}
+
+	[Fact]
+	public void ImageExists_ReturnsTrue_WhenImageIsOnDisk()
+	{
+		// Arrange
+		var listingId = Guid.NewGuid();
+		WriteImage(listingId, [1, 2, 3]);
+
+		// Act & Assert
+		Assert.True(sut.ImageExists(listingId));
+	}
+
+	[Fact]
+	public async Task TryReadImageAsync_ReturnsNull_WhenImageIsMissing()
+	{
+		// Act
+		var result = await sut.TryReadImageAsync(Guid.NewGuid(), CancellationToken.None);
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public async Task TryReadImageAsync_ReturnsStoredBytes()
+	{
+		// Arrange
+		var listingId = Guid.NewGuid();
+		var content = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 };
+		WriteImage(listingId, content);
+
+		// Act
+		var result = await sut.TryReadImageAsync(listingId, CancellationToken.None);
+
+		// Assert
+		Assert.Equal(content, result);
+	}
+
+	[Fact]
+	public async Task TryReadImageAsync_ReadsOnlyTheRequestedListing()
+	{
+		// Arrange
+		// Sharding podle prvních dvou znaků Id nesmí smíchat inzeráty ve stejné podsložce.
+		var first = Guid.NewGuid();
+		var second = Guid.NewGuid();
+		WriteImage(first, [1]);
+		WriteImage(second, [2]);
+
+		// Act & Assert
+		Assert.Equal([1], await sut.TryReadImageAsync(first, CancellationToken.None));
+		Assert.Equal([2], await sut.TryReadImageAsync(second, CancellationToken.None));
+	}
+}


### PR DESCRIPTION
## Shrnutí

Testovací sada pokrývala scrapery, parsování cen, detekci vyřazených inzerátů a validátor scraper úlohy, ale jádro zpracování scrapu a celá větev servisních operací nad obrázky byly bez jediného testu. Tenhle PR doplňuje **85 unit testů** do míst, kde regrese tiše poškodí data nebo zahodí notifikaci.

**Žádná změna produkčního kódu.**

## Co přibylo

### BackfillListingImages (7 testů)

Endpoint z #93 neměl pokrytí vůbec. Nejcennější je test tichého přeskočení: `DownloadImageAsync` vrací `void` a bez chyby se vrátí i u neplatné URL, nepovoleného cíle nebo odpovědi bez `Content-Type: image/*`. Handler proto po každém volání znovu ověřuje existenci souboru — kdyby se tahle post-kontrola vypustila, `downloadedCount` by začal lhát.

Dál je pokrytý strop 200 stažení na běh včetně toho, že se do něj **nezapočítávají** už nakešované inzeráty (jinak by dlouhý ocas hotových náhledů limit vyčerpal a backfill by se nikdy nedostal k práci) a propouštění `OperationCanceledException`.

### ListingChangeProcessor (8 testů)

Jádro scrapu, dosud netestované. Hlídá, že se do `PriceHistory` zapisuje **předchozí** cena s původním `PriceFrom` (ne nová cena s aktuálním časem), že se cenová změna u inzerátu, který v DB není, tiše přeskočí, a že se existující inzeráty netahají z DB, když v reportu žádná cenová změna není.

### ScrapingReportProcessor + notifikace + stahování obrázků (13 testů)

Pořadí kroků je tu funkční požadavek, ne detail: obrázky se smí stahovat až **po** `SaveChangesAsync`, jinak inzeráty ještě nemají přidělené `Id` a soubory by se uložily pod špatnou cestou. Test to fixuje explicitně.

Druhý zásadní invariant — selhání notifikace nesmí dojít k uložení, aby další běh notifikaci zopakoval — je pokrytý z obou stran: že `ListingNotificationService` při neúspěchu vyhodí, i že `ScrapingReportProcessor` pak neuloží a nestahuje.

### TaskSchedulerService (9 testů)

Neplatný cron u jedné úlohy nesmí shodit načtení ostatních. Uložený `NextRunAt` má přednost před přepočtem — bez toho by „spustit teď" (které nastaví `NextRunAt` na aktuální čas) při nejbližším načtení úloh přepočet zahodil. Nezmapovaný potomek `TaskBase` musí spadnout na `NotSupportedException`, ne se tiše přestat plánovat.

### Create/Update ScraperTask (16 testů)

`NextRunAt` se počítá jen u zapnuté úlohy a přepočítává se **jen** při změně cronu nebo enabled — pouhé přejmenování úlohy nesmí posunout už naplánovaný běh. Dál kompletní nahrazení recipients/targets včetně vyprázdnění a vyvolání domain eventů.

### ReportTaskCommandValidator (12 testů)

Zrcadlí existující `ScraperTaskCommandValidatorTests`, které pro report úlohu chyběly.

### Infrastructure: TaskLogStore a úložiště obrázků (23 testů)

`TaskLogStore` — zkrácení po počtu řádků i po celkové velikosti (málo dlouhých řádků nesmí limit obejít), hlášení o zkrácení právě jednou, izolace mezi úlohami, `Append` bez `StartCapture` jako no-op.

`ListingImagePathResolver` + `ListingImageReader` — rozvržení úložiště `{root}/{id[..2]}/{id}.jpg` a fallback na výchozí cestu. Reader jede proti skutečnému disku v temp adresáři, takže se ověří i to, že reader a resolver míří na tentýž soubor.

## Změna závislostí

`Microsoft.Extensions.Configuration` přidán do `Directory.Packages.props` a do `Infrastructure.Tests`. Testy resolveru potřebují `ConfigurationBuilder` s in-memory kolekcí; projekt měl dosud jen `.Abstractions`, které nesou samotné `IConfiguration` bez implementace. Jen testovací závislost, produkční projekty se nemění.

## Ověření

Celá sada zelená: **226/226** (Application 130, Infrastructure 71, Domain 15, Integration 10) — z toho 85 nových. Ověřeno přesně tím příkazem, který jede v CI:

```
dotnet build --no-restore -c Release
dotnet test --no-build -c Release --verbosity normal --report-trx \
  --coverage --coverage-output-format cobertura --results-directory ./TestResults
```

## Poznámka k MTP

Při psaní se potvrdilo, že tichá past popsaná v #94 je širší, než se zdálo: pod Microsoft Testing Platform zeruje běh i `--nologo`. Příkaz `dotnet test <projekt> --nologo` doběhne s „Spustila se nula testů" a exit code 5 místo toho, aby neznámý přepínač odmítl. CI ho nepoužívá, takže se to nikde neprojevuje, ale lokálně to umí splést.