### PR TITLE
Feat: tlačítko pro dotažení chybějících náhledů na stránce Reality

### DIFF
--- a/Web.Api/Endpoints/Maintenance/BackfillListingImagesEndpoint.cs
+++ b/Web.Api/Endpoints/Maintenance/BackfillListingImagesEndpoint.cs
@@ -1,6 +1,7 @@
 using RealityScraper.Application.Abstractions.Messaging;
 using RealityScraper.Application.Features.Maintenance.BackfillListingImages;
 using RealityScraper.Web.Api.Infrastructure;
+using RealityScraper.Web.Api.Mappers.Maintenance;
 
 namespace RealityScraper.Web.Api.Endpoints.Maintenance;
 
@@ -15,7 +16,7 @@ internal sealed class BackfillListingImagesEndpoint : IEndpoint
 			var result = await commandHandler.Handle(new BackfillListingImagesCommand(), cancellationToken);
 
 			return result.IsSuccess
-				? Results.Ok(result.Value)
+				? Results.Ok(BackfillListingImagesDtoMapper.MapToResult(result.Value))
 				: CustomResults.Problem(result);
 		});
 	}

--- a/Web.Api/Mappers/Maintenance/BackfillListingImagesDtoMapper.cs
+++ b/Web.Api/Mappers/Maintenance/BackfillListingImagesDtoMapper.cs
@@ -1,0 +1,18 @@
+using RealityScraper.Application.Features.Maintenance.BackfillListingImages;
+
+namespace RealityScraper.Web.Api.Mappers.Maintenance;
+
+public static class BackfillListingImagesDtoMapper
+{
+	public static Web.Shared.Models.Maintenance.BackfillListingImagesResult MapToResult(
+		BackfillListingImagesResult dto)
+	{
+		return new Web.Shared.Models.Maintenance.BackfillListingImagesResult
+		{
+			CheckedCount = dto.CheckedCount,
+			DownloadedCount = dto.DownloadedCount,
+			FailedCount = dto.FailedCount,
+			RemainingCount = dto.RemainingCount
+		};
+	}
+}

--- a/Web.Client/Pages/Listings/ListingListPage.razor
+++ b/Web.Client/Pages/Listings/ListingListPage.razor
@@ -34,6 +34,16 @@
     </div>
 </div>
 
+<div class="d-flex justify-content-end mb-3">
+    <HxButton Text="Dotáhnout chybějící náhledy"
+              Icon="BootstrapIcon.Images"
+              Color="ThemeColor.Primary"
+              Outline="true"
+              OnClick="HandleBackfillImagesClick"
+              Enabled="!backfillRunning"
+              Tooltip="Stáhne chybějící náhledy k živým inzerátům z jejich uložené URL." />
+</div>
+
 <HxGrid @ref="grid" TItem="ListingResult" DataProvider="LoadData" Responsive="true">
     <Columns>
         <HxGridColumn HeaderText="Náhled">

--- a/Web.Client/Pages/Listings/ListingListPage.razor.cs
+++ b/Web.Client/Pages/Listings/ListingListPage.razor.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Havit.Blazor.Components.Web;
 using Havit.Blazor.Components.Web.Bootstrap;
 using RealityScraper.Web.Shared.Models.Listings;
+using RealityScraper.Web.Shared.Models.Maintenance;
 using RealityScraper.Web.Shared.Models.ScraperTasks;
 
 namespace RealityScraper.Web.Client.Pages.Listings;
@@ -30,6 +31,7 @@ public partial class ListingListPage(
 	private string? searchTerm;
 	private List<PriceHistoryRow>? priceHistoryRows;
 	private string priceHistoryOffcanvasTitle = "Historie cen";
+	private bool backfillRunning;
 
 	protected override async Task OnInitializedAsync()
 	{
@@ -104,6 +106,61 @@ public partial class ListingListPage(
 		{
 			messenger.AddError("Nepodařilo se načíst historii cen.");
 		}
+	}
+
+	private async Task HandleBackfillImagesClick()
+	{
+		backfillRunning = true;
+		try
+		{
+			using var response = await http.PostAsync("/api/maintenance/listing-images/backfill", null);
+			if (!response.IsSuccessStatusCode)
+			{
+				messenger.AddError("Nepodařilo se dotáhnout chybějící náhledy.");
+				return;
+			}
+
+			var result = await response.Content.ReadFromJsonAsync<BackfillListingImagesResult>();
+			if (result == null)
+			{
+				messenger.AddError("Nepodařilo se dotáhnout chybějící náhledy.");
+				return;
+			}
+
+			messenger.AddInformation(BuildBackfillMessage(result));
+		}
+		catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+		{
+			messenger.AddError("Nepodařilo se dotáhnout chybějící náhledy.");
+		}
+		finally
+		{
+			backfillRunning = false;
+		}
+	}
+
+	private static string BuildBackfillMessage(BackfillListingImagesResult result)
+	{
+		// RemainingCount roste až po vyčerpání limitu jednoho běhu, takže nulové
+		// stažení i selhání znamená, že opravdu nebylo co dotahovat.
+		if (result.DownloadedCount == 0 && result.FailedCount == 0)
+		{
+			return $"Všechny živé inzeráty mají náhled (prověřeno {result.CheckedCount}).";
+		}
+
+		var message = $"Dotaženo {result.DownloadedCount} náhledů (prověřeno {result.CheckedCount}).";
+
+		if (result.FailedCount > 0)
+		{
+			message += $" Nepodařilo se: {result.FailedCount}.";
+		}
+
+		if (result.RemainingCount > 0)
+		{
+			message += $" Zbývá {result.RemainingCount} – spusťte akci znovu.";
+		}
+
+		return message;
 	}
 
 	private static List<PriceHistoryRow> BuildPriceHistoryRows(List<PriceHistoryResult> history)

--- a/Web.Shared/Models/Maintenance/BackfillListingImagesResult.cs
+++ b/Web.Shared/Models/Maintenance/BackfillListingImagesResult.cs
@@ -1,0 +1,19 @@
+namespace RealityScraper.Web.Shared.Models.Maintenance;
+
+public class BackfillListingImagesResult
+{
+	/// <summary>
+	/// Počet prověřených živých inzerátů s vyplněnou URL obrázku.
+	/// </summary>
+	public int CheckedCount { get; set; }
+
+	public int DownloadedCount { get; set; }
+
+	public int FailedCount { get; set; }
+
+	/// <summary>
+	/// Inzeráty, na které se kvůli limitu jednoho běhu nedostalo. Nenulová hodnota
+	/// znamená, že je potřeba akci spustit znovu.
+	/// </summary>
+	public int RemainingCount { get; set; }
+}


### PR DESCRIPTION
## Shrnutí

Endpoint `POST /api/maintenance/listing-images/backfill` z #93 jde v produkci vyvolat jen obtížně — je to POST, Scalar UI je v produkci vypnuté a endpoint vyžaduje přihlášení. Pro jednorázovou údržbu to znamená obcházet to přes devtools konzoli.

Tlačítko na stránce Reality běží v už přihlášené session (stejně jako „Spustit" u scraper tasků), takže akci spustí jedním kliknutím a rovnou ukáže výsledek.

## Změny

- **Tlačítko „Dotáhnout chybějící náhledy"** nad gridem na `/listings`. Po dobu běhu je disabled, aby nešlo spustit dvakrát.
- **Hlášky přes `HxMessenger`**: `Dotaženo 2 náhledů (prověřeno 2).`, u nenulového `FailedCount` se doplní `Nepodařilo se: N.` a u nenulového `RemainingCount` pobídka `Zbývá N – spusťte akci znovu.` Když není co dotahovat, hlásí `Všechny živé inzeráty mají náhled (prověřeno N).`
- **Sdílený model odpovědi**: endpoint dosud vracel přímo Application typ `BackfillListingImagesResult`. Nově se mapuje na `Web.Shared.Models.Maintenance.BackfillListingImagesResult` přes `BackfillListingImagesDtoMapper`, konzistentně se zbytkem API. Klient má na čem deserializovat a nekouká přes vrstvu. **Tvar JSON se nemění**, jde jen o typ na hranici.
