### PR TITLE
Fix: obnova úvodního snímku inzerátu po jeho změně na portálu

### DIFF
--- a/Application.Tests/Features/Scraping/Builders/ScrapingReportBuilderTests.cs
+++ b/Application.Tests/Features/Scraping/Builders/ScrapingReportBuilderTests.cs
@@ -59,12 +59,12 @@ public class ScrapingReportBuilderTests
 		// arrange
 		var listings1 = new List<ScraperListingItem>
 		{
-			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U1", ExternalId = "Ext1", ImageUrl = string.Empty }
+			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U1", ExternalId = "Ext1", ImageUrl = "https://cdn/a.jpg" }
 		};
 
 		var listings2 = new List<ScraperListingItem>
 		{
-			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U2", ExternalId = "Ext1", ImageUrl = string.Empty }
+			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U2", ExternalId = "Ext1", ImageUrl = "https://cdn/b.jpg" }
 		};
 
 		var sut = CreateBuilder();
@@ -79,7 +79,11 @@ public class ScrapingReportBuilderTests
 		Assert.Equal(2, result.NewListingsCount);
 		Assert.Equal(2, result.TotalListingsCount);
 		Assert.All(result.Results, r => Assert.Equal(1, r.TotalListingsCount));
-		Assert.Equal(new HashSet<string> { "Ext1" }, result.SeenExternalIds);
+
+		// SeenListings je mapa podle externího ID, takže duplicitu drží jen jednou a vyhrává
+		// poslední portál. Add() by na duplicitním klíči shodil celý běh.
+		Assert.Equal(["Ext1"], result.SeenListings.Keys);
+		Assert.Equal("https://cdn/b.jpg", result.SeenListings["Ext1"].ImageUrl);
 	}
 
 	[Fact]
@@ -171,7 +175,7 @@ public class ScrapingReportBuilderTests
 	}
 
 	[Fact]
-	public async Task ScrapingReportBuilder_Build_PropagatesSuccessAndSeenExternalIds()
+	public async Task ScrapingReportBuilder_Build_PropagatesSuccessAndSeenListings()
 	{
 		// arrange
 		var listings = new List<ScraperListingItem>
@@ -189,7 +193,7 @@ public class ScrapingReportBuilderTests
 
 		// assert
 		Assert.True(result.ScrapingSucceeded);
-		Assert.Equal(new HashSet<string> { "Ext1", "Ext2" }, result.SeenExternalIds);
+		Assert.Equal(["Ext1", "Ext2"], result.SeenListings.Keys.Order());
 	}
 
 	[Fact]
@@ -236,6 +240,49 @@ public class ScrapingReportBuilderTests
 
 		// assert
 		Assert.True(result.ScrapingSucceeded);
+	}
+
+	[Fact]
+	public async Task ScrapingReportBuilder_ProcessScraperResults_SeenListingsCarryFreshImageUrlOfUnchangedListing()
+	{
+		// arrange - existující inzerát beze změny ceny, portál mu ale vyměnil titulní fotku
+		var listings = new List<ScraperListingItem>
+		{
+			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U1", ExternalId = "Ext1", ImageUrl = "https://cdn/new.jpg" }
+		};
+
+		var sut = CreateBuilder([new Listing { ExternalId = "Ext1", Price = 1000, ImageUrl = "https://cdn/old.jpg" }]);
+		sut.ForScrapingReport(Guid.NewGuid(), "task");
+
+		// act
+		await sut.ProcessScraperResultsAsync("siteName", new ScraperRunResult(true, listings), CancellationToken.None);
+		var result = sut.Build();
+
+		// assert - nezměněný inzerát není ani nový, ani cenově změněný, přesto musí čerstvá URL projít dál
+		Assert.Equal(0, result.NewListingsCount);
+		Assert.Equal(0, result.PriceChangedListingsCount);
+		Assert.Equal("https://cdn/new.jpg", result.SeenListings["Ext1"].ImageUrl);
+	}
+
+	[Fact]
+	public async Task ScrapingReportBuilder_ForScrapingReport_ClearsSeenListings()
+	{
+		// arrange
+		var listings = new List<ScraperListingItem>
+		{
+			new ScraperListingItem { Title = "T1", Price = 1000, Location = "L1", Url = "U1", ExternalId = "Ext1", ImageUrl = string.Empty }
+		};
+
+		var sut = CreateBuilder();
+		sut.ForScrapingReport(Guid.NewGuid(), "task");
+		await sut.ProcessScraperResultsAsync("siteName", new ScraperRunResult(true, listings), CancellationToken.None);
+
+		// act
+		sut.ForScrapingReport(Guid.NewGuid(), "task2");
+		var result = sut.Build();
+
+		// assert
+		Assert.Empty(result.SeenListings);
 	}
 
 	private static ScrapingReportBuilder CreateBuilder(List<Listing>? existingListings = null)

--- a/Application.Tests/Features/Scraping/ListingChangeProcessorTests.cs
+++ b/Application.Tests/Features/Scraping/ListingChangeProcessorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using RealityScraper.Application.Features.Scraping;
+using RealityScraper.Application.Features.Scraping.Model;
 using RealityScraper.Application.Features.Scraping.Model.Report;
 using RealityScraper.Application.Interfaces.Repositories.Realty;
 using RealityScraper.Domain.Entities.Realty;
@@ -53,7 +54,25 @@ public class ListingChangeProcessorTests
 		};
 	}
 
-	private static Listing ExistingListing(string externalId, decimal? price)
+	private static ScraperListingItem Seen(
+		string externalId,
+		string imageUrl,
+		string? title = null,
+		string? location = null,
+		string? url = null)
+	{
+		return new ScraperListingItem
+		{
+			Title = title ?? "Prodej domu",
+			Price = 5_000_000,
+			Location = location ?? "Brno",
+			Url = url ?? $"https://example.com/{externalId}",
+			ImageUrl = imageUrl,
+			ExternalId = externalId
+		};
+	}
+
+	private static Listing ExistingListing(string externalId, decimal? price, string imageUrl = "")
 	{
 		return new Listing
 		{
@@ -62,7 +81,7 @@ public class ListingChangeProcessorTests
 			Title = "Prodej domu",
 			Location = "Brno",
 			Url = $"https://example.com/{externalId}",
-			ImageUrl = string.Empty,
+			ImageUrl = imageUrl,
 			Price = price,
 			CreatedAt = Earlier,
 			LastSeenAt = Earlier,
@@ -73,13 +92,19 @@ public class ListingChangeProcessorTests
 
 	private static ScrapingReport CreateReport(params PortalReport[] results)
 	{
+		return CreateReport([], results);
+	}
+
+	private static ScrapingReport CreateReport(IEnumerable<ScraperListingItem> seenListings, params PortalReport[] results)
+	{
 		return new ScrapingReport
 		{
 			ScraperTaskId = TaskId,
 			TaskName = "task",
 			ReportDate = Now,
 			ScrapingSucceeded = true,
-			Results = results.ToList()
+			Results = results.ToList(),
+			SeenListings = seenListings.ToDictionary(l => l.ExternalId)
 		};
 	}
 
@@ -141,10 +166,11 @@ public class ListingChangeProcessorTests
 	}
 
 	[Fact]
-	public async Task ProcessChangesAsync_DoesNotLoadExistingListings_WhenThereAreNoPriceChanges()
+	public async Task ProcessChangesAsync_DoesNotLoadExistingListings_WhenThereIsNothingToRefresh()
 	{
 		// Arrange
-		// Dotaz do DB má smysl jen kvůli cenovým změnám - u samotných nových inzerátů je zbytečný.
+		// Dotaz do DB má smysl jen kvůli cenovým změnám a obnově údajů viděných inzerátů -
+		// u samotných nových inzerátů je zbytečný.
 		var report = CreateReport(Portal(newListings: [NewItem("ext-1")]));
 		var sut = CreateSut();
 
@@ -179,7 +205,7 @@ public class ListingChangeProcessorTests
 		Assert.Equal(Now, existing.PriceFrom);
 		Assert.Equal(Now, existing.LastSeenAt);
 
-		// Cenová změna nemění obrázek, takže se nestahuje znovu.
+		// Report pro tenhle inzerát nenese viděnou položku, takže není z čeho obnovovat obrázek.
 		Assert.Empty(toDownload);
 	}
 
@@ -243,6 +269,231 @@ public class ListingChangeProcessorTests
 
 		// Assert
 		Assert.Equal([5_500_000, 5_000_000], existing.PriceHistories.Select(h => h.Price));
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_UpdatesImageUrl_WhenScrapedUrlDiffers()
+	{
+		// Arrange - portál vyměnil titulní fotku, uložená URL je od té chvíle mrtvá
+		var existing = ExistingListing("ext-1", 5_000_000, "https://cdn.example.com/photos/old.jpg");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport([Seen("ext-1", "https://cdn.example.com/photos/new.jpg")], Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal("https://cdn.example.com/photos/new.jpg", existing.ImageUrl);
+		Assert.Same(existing, Assert.Single(toDownload));
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_FillsMissingImageUrl_WhenStoredValueIsEmpty()
+	{
+		// Arrange - selektor obrázku selhal v den založení, backfill takový inzerát nikdy nedotáhne
+		var existing = ExistingListing("ext-1", 5_000_000);
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport([Seen("ext-1", "https://cdn.example.com/photos/first.jpg")], Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal("https://cdn.example.com/photos/first.jpg", existing.ImageUrl);
+		Assert.Same(existing, Assert.Single(toDownload));
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_DoesNotOverwriteImageUrl_WhenScrapedUrlIsEmpty()
+	{
+		// Arrange - prázdná hodnota znamená selhaný selektor, ne inzerát bez fotky
+		var existing = ExistingListing("ext-1", 5_000_000, "https://cdn.example.com/photos/good.jpg");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport([Seen("ext-1", string.Empty)], Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal("https://cdn.example.com/photos/good.jpg", existing.ImageUrl);
+		Assert.Empty(toDownload);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_DoesNotQueueDownload_WhenImageUrlIsUnchanged()
+	{
+		// Arrange
+		var existing = ExistingListing("ext-1", 5_000_000, "https://cdn.example.com/photos/same.jpg");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport([Seen("ext-1", "https://cdn.example.com/photos/same.jpg")], Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal("https://cdn.example.com/photos/same.jpg", existing.ImageUrl);
+		Assert.Empty(toDownload);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_UpdatesImageUrlButSkipsDownload_WhenOnlyCdnHostOrQueryDiffers()
+	{
+		// Arrange - jiný CDN uzel a jiné parametry zmenšení, ale pořád tatáž fotka. Bez porovnání
+		// na cestu bez query by se každý běh stahovaly všechny obrázky znovu.
+		var existing = ExistingListing("ext-1", 5_000_000, "https://d18-a.sdn.cz/d_18/c_img_x/foo.jpeg?fl=res,400,300,1");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport([Seen("ext-1", "https://d19-a.sdn.cz/d_18/c_img_x/foo.jpeg?fl=res,800,600,1")], Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert - do DB jde čerstvá URL (query může nést podepsaný token), soubor se nestahuje
+		Assert.Equal("https://d19-a.sdn.cz/d_18/c_img_x/foo.jpeg?fl=res,800,600,1", existing.ImageUrl);
+		Assert.Empty(toDownload);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_SkipsImageUrlRefresh_WhenUrlExceedsColumnLength()
+	{
+		// Arrange - hodnota delší než limit sloupce by shodila uložení celého běhu
+		var existing = ExistingListing("ext-1", 5_000_000, "https://cdn.example.com/photos/old.jpg");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var tooLongUrl = "https://cdn.example.com/" + new string('a', 480) + ".jpg";
+		var report = CreateReport([Seen("ext-1", tooLongUrl)], Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.True(tooLongUrl.Length > 500);
+		Assert.Equal("https://cdn.example.com/photos/old.jpg", existing.ImageUrl);
+		Assert.Empty(toDownload);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_RefreshesImageUrlOfPriceChangedListing_WithoutDuplicateDownload()
+	{
+		// Arrange - inzerát je současně v cenových změnách i mezi viděnými s novou fotkou
+		var existing = ExistingListing("ext-1", 5_000_000, "https://cdn.example.com/photos/old.jpg");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport(
+			[Seen("ext-1", "https://cdn.example.com/photos/new.jpg")],
+			Portal(priceChanged: [PriceChangedItem("ext-1", 4_500_000, 5_000_000)]));
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal(4_500_000, existing.Price);
+		Assert.Equal(5_000_000, Assert.Single(existing.PriceHistories).Price);
+		Assert.Equal("https://cdn.example.com/photos/new.jpg", existing.ImageUrl);
+		Assert.Same(existing, Assert.Single(toDownload));
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_DoesNotQueueNewListingTwice_WhenItIsAlsoAmongSeenListings()
+	{
+		// Arrange - nový inzerát je mezi viděnými vždycky, v databázi ale ještě není
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		var report = CreateReport(
+			[Seen("ext-1", "https://example.com/ext-1.jpg")],
+			Portal(newListings: [NewItem("ext-1")]));
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal("ext-1", Assert.Single(toDownload).ExternalId);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_IgnoresSeenListing_WhenItIsNotInDatabase()
+	{
+		// Arrange
+		var other = ExistingListing("ext-other", 1_000_000, "https://cdn.example.com/photos/other.jpg");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([other]);
+		var report = CreateReport([Seen("ext-missing", "https://cdn.example.com/photos/new.jpg")], Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Empty(toDownload);
+		Assert.Equal("https://cdn.example.com/photos/other.jpg", other.ImageUrl);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_RefreshesTitleLocationAndUrl_WhenTheyChangeOnPortal()
+	{
+		// Arrange - stejná vada "zapiš jednou, nikdy neaktualizuj" platila i pro texty
+		var existing = ExistingListing("ext-1", 5_000_000, "https://cdn.example.com/photos/same.jpg");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport(
+			[Seen("ext-1", "https://cdn.example.com/photos/same.jpg", title: "Prodej domu 120 m2", location: "Brno-střed", url: "https://example.com/prodej-domu/ext-1")],
+			Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal("Prodej domu 120 m2", existing.Title);
+		Assert.Equal("Brno-střed", existing.Location);
+		Assert.Equal("https://example.com/prodej-domu/ext-1", existing.Url);
+
+		// Texty se stahování obrázku netýkají.
+		Assert.Empty(toDownload);
+	}
+
+	[Fact]
+	public async Task ProcessChangesAsync_DoesNotRefreshText_WhenOnlyWhitespaceDiffers()
+	{
+		// Arrange - whitespace z markupu by jinak "měnil" hodnotu při každém běhu
+		var existing = ExistingListing("ext-1", 5_000_000, "https://cdn.example.com/photos/same.jpg");
+		listingRepositoryMock
+			.Setup(x => x.GetByScraperTaskIdAsync(TaskId, It.IsAny<CancellationToken>()))
+			.ReturnsAsync([existing]);
+		var report = CreateReport(
+			[Seen("ext-1", "https://cdn.example.com/photos/same.jpg", title: "  Prodej domu  ", location: "\tBrno\r\n")],
+			Portal());
+		var sut = CreateSut();
+
+		// Act
+		var toDownload = await sut.ProcessChangesAsync(report, CancellationToken.None);
+
+		// Assert
+		Assert.Equal("Prodej domu", existing.Title);
+		Assert.Equal("Brno", existing.Location);
+		Assert.Empty(toDownload);
 	}
 
 	[Fact]

--- a/Application.Tests/Features/Scraping/RemovedListingDetectorTests.cs
+++ b/Application.Tests/Features/Scraping/RemovedListingDetectorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using RealityScraper.Application.Features.Scraping;
+using RealityScraper.Application.Features.Scraping.Model;
 using RealityScraper.Application.Features.Scraping.Model.Report;
 using RealityScraper.Application.Interfaces.Repositories.Realty;
 using RealityScraper.Domain.Entities.Realty;
@@ -54,7 +55,16 @@ public class RemovedListingDetectorTests
 			TaskName = "task",
 			ScrapingSucceeded = succeeded,
 			Results = results,
-			SeenExternalIds = new HashSet<string>(seenExternalIds)
+			SeenListings = seenExternalIds.ToDictionary(
+				externalId => externalId,
+				externalId => new ScraperListingItem
+				{
+					Title = "Title",
+					Location = "Location",
+					Url = "Url",
+					ImageUrl = string.Empty,
+					ExternalId = externalId
+				})
 		};
 	}
 

--- a/Application/Features/Scraping/Builders/ScrapingReportBuilder.cs
+++ b/Application/Features/Scraping/Builders/ScrapingReportBuilder.cs
@@ -17,7 +17,7 @@ public class ScrapingReportBuilder
 	private Dictionary<string, Listing>? existingListingsByExternalId;
 	private readonly Dictionary<string, ScraperResultBuilder> scraperBuilders = new();
 	private readonly HashSet<string> processedListings = new(); // Klíč "siteName|externalId" - prevence duplikátů mezi targety téhož portálu
-	private readonly HashSet<string> seenExternalIds = new();
+	private readonly Dictionary<string, ScraperListingItem> seenListings = new();
 
 	private readonly IListingRepository listingRepository;
 	private readonly IDateTimeProvider dateTimeProvider;
@@ -43,7 +43,7 @@ public class ScrapingReportBuilder
 		existingListingsByExternalId = null;
 		scraperBuilders.Clear();
 		processedListings.Clear();
-		seenExternalIds.Clear();
+		seenListings.Clear();
 		return this;
 	}
 
@@ -148,7 +148,13 @@ public class ScrapingReportBuilder
 
 		builder.IncrementTotalCount();
 		processedListings.Add(listingKey);
-		seenExternalIds.Add(listing.ExternalId);
+
+		// Čerstvě nascrapovaná data si necháme i u nezměněných inzerátů - na portálu se během
+		// života inzerátu mění titulní fotka a bez toho by uložená URL zůstala navždy ta první.
+		// Indexer, ne Add() - stejné externí ID může přijít ze dvou portálů (processedListings
+		// hlídá duplicity jen v rámci jednoho portálu) a Add() by shodil celý běh.
+		seenListings[listing.ExternalId] = listing;
+
 		return this;
 	}
 
@@ -177,7 +183,7 @@ public class ScrapingReportBuilder
 			TaskName = scraperTaskName,
 			Results = results,
 			ScrapingSucceeded = allScrapersSucceeded,
-			SeenExternalIds = new HashSet<string>(seenExternalIds),
+			SeenListings = new Dictionary<string, ScraperListingItem>(seenListings),
 			FailedListingsCount = failedListingsCount,
 			AnyTargetEmpty = anyTargetEmpty
 		};

--- a/Application/Features/Scraping/ListingChangeProcessor.cs
+++ b/Application/Features/Scraping/ListingChangeProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using RealityScraper.Application.Features.Scraping.Model;
 using RealityScraper.Application.Features.Scraping.Model.Report;
 using RealityScraper.Application.Interfaces.Repositories.Realty;
 using RealityScraper.Domain.Entities.Realty;
@@ -8,6 +9,12 @@ namespace RealityScraper.Application.Features.Scraping;
 
 public class ListingChangeProcessor : IListingChangeProcessor
 {
+	// Limity sloupců podle ListingConfiguration - delší hodnota by shodila uložení celého běhu.
+	private const int MaxImageUrlLength = 500;
+	private const int MaxTitleLength = 300;
+	private const int MaxLocationLength = 300;
+	private const int MaxUrlLength = 500;
+
 	private readonly IListingRepository listingRepository;
 	private readonly IDateTimeProvider dateTimeProvider;
 	private readonly ILogger<ListingChangeProcessor> logger;
@@ -27,8 +34,9 @@ public class ListingChangeProcessor : IListingChangeProcessor
 		var listingsToDownload = new List<Listing>();
 		var now = dateTimeProvider.UtcNow;
 
+		// Existující inzeráty se načtou kvůli cenovým změnám i kvůli obnově údajů z portálu.
 		Dictionary<string, Listing>? existingByExternalId = null;
-		if (report.Results.Any(r => r.PriceChangedListings.Any()))
+		if (report.SeenListings.Count > 0 || report.Results.Any(r => r.PriceChangedListings.Any()))
 		{
 			existingByExternalId = (await listingRepository.GetByScraperTaskIdAsync(report.ScraperTaskId, cancellationToken))
 				.ToDictionary(l => l.ExternalId);
@@ -78,8 +86,136 @@ public class ListingChangeProcessor : IListingChangeProcessor
 			}
 		}
 
+		var refreshedCount = 0;
+		var imageChangedCount = 0;
+
+		if (existingByExternalId != null)
+		{
+			foreach (var seen in report.SeenListings.Values)
+			{
+				// Nově vkládané inzeráty v mapě nejsou (načetla se před jejich vložením),
+				// takže se jejich obrázek nezařadí ke stažení podruhé.
+				if (!existingByExternalId.TryGetValue(seen.ExternalId, out var existingListing))
+				{
+					continue;
+				}
+
+				var refreshed = TryRefreshImageUrl(existingListing, seen, out var imageChanged);
+
+				if (TryGetRefreshedText(existingListing.Title, seen.Title, MaxTitleLength, out var title))
+				{
+					existingListing.Title = title;
+					refreshed = true;
+				}
+
+				if (TryGetRefreshedText(existingListing.Location, seen.Location, MaxLocationLength, out var location))
+				{
+					existingListing.Location = location;
+					refreshed = true;
+				}
+
+				if (TryGetRefreshedText(existingListing.Url, seen.Url, MaxUrlLength, out var url))
+				{
+					existingListing.Url = url;
+					refreshed = true;
+				}
+
+				if (!refreshed)
+				{
+					continue;
+				}
+
+				refreshedCount++;
+				if (imageChanged)
+				{
+					imageChangedCount++;
+					listingsToDownload.Add(existingListing);
+				}
+			}
+		}
+
 		logger.LogInformation("Zpracováno {NewCount} nových a {ChangedCount} cenově změněných listingů.", report.NewListingsCount, report.PriceChangedListingsCount);
 
+		if (refreshedCount > 0)
+		{
+			logger.LogInformation("Obnoveny údaje u {RefreshedCount} z {SeenCount} viděných inzerátů, u {ImageChangedCount} se změnil obrázek a stáhne se znovu.",
+				refreshedCount, report.SeenListings.Count, imageChangedCount);
+		}
+
+		// Vysoký podíl znovu stahovaných obrázků znamená nestabilní URL na portálu (podepsané odkazy,
+		// náhodný uzel v cestě) - pak je potřeba upravit GetImageIdentity, jinak se každý běh
+		// stahují všechny obrázky znovu.
+		if (report.SeenListings.Count >= 10 && imageChangedCount > report.SeenListings.Count / 2)
+		{
+			logger.LogWarning("Úloha '{TaskName}': obrázek se mění u většiny inzerátů ({ImageChangedCount} z {SeenCount}), zkontrolujte stabilitu URL z portálu.",
+				report.TaskName, imageChangedCount, report.SeenListings.Count);
+		}
+
 		return listingsToDownload;
+	}
+
+	/// <summary>
+	/// Přepíše uloženou URL titulní fotky čerstvě nascrapovanou hodnotou. Vrací true, pokud se URL
+	/// změnila; <paramref name="imageChanged"/> říká, zda jde o jiný obrázek (nutné stáhnout znovu),
+	/// nebo jen o jinou variantu téže fotky (jiný CDN uzel, jiné parametry zmenšení).
+	/// </summary>
+	private bool TryRefreshImageUrl(Listing listing, ScraperListingItem seen, out bool imageChanged)
+	{
+		imageChanged = false;
+
+		// Prázdná hodnota znamená selhaný selektor - dobrou uloženou URL přepsat nesmí.
+		if (string.IsNullOrWhiteSpace(seen.ImageUrl))
+		{
+			return false;
+		}
+
+		if (seen.ImageUrl.Length > MaxImageUrlLength)
+		{
+			logger.LogWarning("URL obrázku inzerátu {ExternalId} přesahuje {MaxLength} znaků, obnova se přeskakuje.", seen.ExternalId, MaxImageUrlLength);
+			return false;
+		}
+
+		if (string.Equals(listing.ImageUrl, seen.ImageUrl, StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		imageChanged = !string.Equals(GetImageIdentity(listing.ImageUrl), GetImageIdentity(seen.ImageUrl), StringComparison.Ordinal);
+
+		logger.LogDebug("Inzerát {ExternalId}: URL titulní fotky změněna z '{OldImageUrl}' na '{NewImageUrl}' (jiný obrázek: {ImageChanged}).",
+			seen.ExternalId, listing.ImageUrl, seen.ImageUrl, imageChanged);
+
+		listing.ImageUrl = seen.ImageUrl;
+		return true;
+	}
+
+	/// <summary>
+	/// Vrátí true a přes <paramref name="refreshed"/> novou hodnotu, pokud se čerstvě nascrapovaný
+	/// text liší od uloženého. Prázdnou hodnotou (selhaný selektor) ani hodnotou nad limit sloupce
+	/// se uložený text nepřepisuje.
+	/// </summary>
+	private static bool TryGetRefreshedText(string stored, string fresh, int maxLength, out string refreshed)
+	{
+		refreshed = stored;
+
+		// Whitespace z markupu by jinak "měnil" hodnotu při každém běhu.
+		var trimmed = fresh.Trim();
+		if (trimmed.Length == 0 || trimmed.Length > maxLength || string.Equals(stored, trimmed, StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		refreshed = trimmed;
+		return true;
+	}
+
+	/// <summary>
+	/// Identita obrázku pro porovnání = cesta bez hostitele a bez query. Portály přehazují inzeráty
+	/// mezi CDN uzly a mění parametry zmenšení, samotný obrázek přitom zůstává stejný - bez tohoto
+	/// ořezu by se každý běh stahovaly všechny obrázky znovu.
+	/// </summary>
+	private static string GetImageIdentity(string imageUrl)
+	{
+		return Uri.TryCreate(imageUrl, UriKind.Absolute, out var uri) ? uri.AbsolutePath : imageUrl;
 	}
 }

--- a/Application/Features/Scraping/Model/Report/ScrapingReport.cs
+++ b/Application/Features/Scraping/Model/Report/ScrapingReport.cs
@@ -17,13 +17,14 @@ public record ScrapingReport
 	public bool ScrapingSucceeded { get; init; }
 
 	/// <summary>
-	/// Externí ID všech inzerátů viděných v tomto běhu (napříč portály).
+	/// Inzeráty viděné v tomto běhu (napříč portály), klíčem je externí ID. Nesou čerstvě
+	/// nascrapované hodnoty, aby šlo obnovit údaje, které se na portálu během života inzerátu mění.
 	/// </summary>
-	public IReadOnlySet<string> SeenExternalIds { get; init; } = new HashSet<string>();
+	public IReadOnlyDictionary<string, ScraperListingItem> SeenListings { get; init; } = new Dictionary<string, ScraperListingItem>();
 
 	/// <summary>
 	/// Počet inzerátů, které se během scrapování nepodařilo zpracovat (selhaly selektory).
-	/// Nenulová hodnota znamená, že SeenExternalIds nemusí být úplné.
+	/// Nenulová hodnota znamená, že SeenListings nemusí být úplné.
 	/// </summary>
 	public int FailedListingsCount { get; init; }
 

--- a/Application/Features/Scraping/RemovedListingDetector.cs
+++ b/Application/Features/Scraping/RemovedListingDetector.cs
@@ -31,7 +31,7 @@ public class RemovedListingDetector : IRemovedListingDetector
 		// vyřazeného) se aktualizuje i při částečném selhání scrapování.
 		foreach (var listing in listings)
 		{
-			if (report.SeenExternalIds.Contains(listing.ExternalId))
+			if (report.SeenListings.ContainsKey(listing.ExternalId))
 			{
 				listing.LastSeenAt = now;
 				if (listing.RemovedAt != null)
@@ -49,7 +49,7 @@ public class RemovedListingDetector : IRemovedListingDetector
 			return;
 		}
 
-		// Nezpracované inzeráty (selhané selektory) nejsou v SeenExternalIds a vypadaly by
+		// Nezpracované inzeráty (selhané selektory) nejsou v SeenListings a vypadaly by
 		// jako vyřazené, přestože na portálu stále existují.
 		if (report.FailedListingsCount > 0)
 		{
@@ -65,7 +65,7 @@ public class RemovedListingDetector : IRemovedListingDetector
 		// prázdný výsledek kteréhokoli z nich by mohl chybně vyřadit jeho inzeráty.
 		if (activeListings.Count > 0)
 		{
-			if (report.SeenExternalIds.Count == 0)
+			if (report.SeenListings.Count == 0)
 			{
 				logger.LogWarning("Scrapování úlohy '{TaskName}' nevrátilo žádné inzeráty, ale v databázi je {Count} aktivních. Detekce vyřazených se přeskakuje.", report.TaskName, activeListings.Count);
 				return;
@@ -91,7 +91,7 @@ public class RemovedListingDetector : IRemovedListingDetector
 
 		foreach (var listing in listings)
 		{
-			if (!report.SeenExternalIds.Contains(listing.ExternalId) && listing.RemovedAt == null)
+			if (!report.SeenListings.ContainsKey(listing.ExternalId) && listing.RemovedAt == null)
 			{
 				listing.RemovedAt = now;
 				removedCount++;

--- a/Infrastructure.Tests/Utilities/ImageDownloadServiceTests.cs
+++ b/Infrastructure.Tests/Utilities/ImageDownloadServiceTests.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using RealityScraper.Application.Interfaces.Scraping;
+using RealityScraper.Domain.Entities.Realty;
+using RealityScraper.Infrastructure.Configuration;
+using RealityScraper.Infrastructure.Utilities;
+
+namespace RealityScraper.Infrastructure.Tests.Utilities;
+
+/// <summary>
+/// Stahování jede proti fake handleru, ukládání proti skutečnému disku v dočasném adresáři.
+/// </summary>
+public sealed class ImageDownloadServiceTests : IDisposable
+{
+	private readonly string root = Path.Combine(Path.GetTempPath(), $"reality-scraper-tests-{Guid.NewGuid()}");
+	private readonly ListingImagePathResolver pathResolver;
+	private readonly CapturingHandler handler = new();
+
+	public ImageDownloadServiceTests()
+	{
+		var configuration = new ConfigurationBuilder()
+			.AddInMemoryCollection(new Dictionary<string, string?> { ["FileStorage:ImagePath"] = root })
+			.Build();
+
+		pathResolver = new ListingImagePathResolver(configuration);
+	}
+
+	public void Dispose()
+	{
+		handler.Dispose();
+
+		if (Directory.Exists(root))
+		{
+			Directory.Delete(root, recursive: true);
+		}
+	}
+
+	private ImageDownloadService CreateSut(string? configuredUserAgent)
+	{
+		return new ImageDownloadService(
+			new StubHttpClientFactory(handler),
+			pathResolver,
+			new AlwaysAllowedUrlSafetyValidator(),
+			Options.Create(new SeleniumOptions { UserAgent = configuredUserAgent }),
+			NullLogger<ImageDownloadService>.Instance);
+	}
+
+	private static Listing CreateListing()
+	{
+		return new Listing
+		{
+			Id = Guid.NewGuid(),
+			ExternalId = "ext-1",
+			Title = "Prodej domu",
+			Location = "Brno",
+			Url = "https://example.com/ext-1",
+			ImageUrl = "https://cdn.example.com/photos/first.jpg"
+		};
+	}
+
+	[Fact]
+	public async Task DownloadImageAsync_SendsConfiguredUserAgent()
+	{
+		// Arrange - bez User-Agenta část CDN odpoví 403 a obrázek se nikdy nestáhne
+		var sut = CreateSut("Mozilla/5.0 (Test) Chrome/999.0.0.0");
+
+		// Act
+		await sut.DownloadImageAsync(CreateListing(), CancellationToken.None);
+
+		// Assert
+		Assert.Equal("Mozilla/5.0 (Test) Chrome/999.0.0.0", handler.LastUserAgent);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	public async Task DownloadImageAsync_FallsBackToDefaultUserAgent_WhenConfigurationIsEmpty(string? configuredUserAgent)
+	{
+		// Arrange
+		var sut = CreateSut(configuredUserAgent);
+
+		// Act
+		await sut.DownloadImageAsync(CreateListing(), CancellationToken.None);
+
+		// Assert - hlavička musí odejít i s prázdnou konfigurací, jinak je to tichý výpadek
+		Assert.StartsWith("Mozilla/5.0", handler.LastUserAgent);
+	}
+
+	[Fact]
+	public async Task DownloadImageAsync_SavesImageToResolvedPath()
+	{
+		// Arrange
+		var listing = CreateListing();
+		var sut = CreateSut("Mozilla/5.0 (Test) Chrome/999.0.0.0");
+
+		// Act
+		await sut.DownloadImageAsync(listing, CancellationToken.None);
+
+		// Assert
+		Assert.Equal(CapturingHandler.ImageBytes, await File.ReadAllBytesAsync(pathResolver.GetImageFilePath(listing.Id), CancellationToken.None));
+	}
+
+	private sealed class CapturingHandler : HttpMessageHandler
+	{
+		public static readonly byte[] ImageBytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+
+		public string? LastUserAgent { get; private set; }
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			LastUserAgent = request.Headers.TryGetValues("User-Agent", out var values) ? string.Join(" ", values) : null;
+
+			var response = new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new ByteArrayContent(ImageBytes)
+			};
+			response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+
+			return Task.FromResult(response);
+		}
+	}
+
+	private sealed class StubHttpClientFactory : IHttpClientFactory
+	{
+		private readonly HttpMessageHandler handler;
+
+		public StubHttpClientFactory(HttpMessageHandler handler)
+		{
+			this.handler = handler;
+		}
+
+		// disposeHandler: false - handler přežívá jednotlivé klienty a test si ho uklidí sám.
+		public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+	}
+
+	private sealed class AlwaysAllowedUrlSafetyValidator : IUrlSafetyValidator
+	{
+		public Task<bool> IsPublicHttpTargetAsync(Uri uri, CancellationToken cancellationToken) => Task.FromResult(true);
+	}
+}

--- a/Infrastructure/Utilities/ImageDownloadService.cs
+++ b/Infrastructure/Utilities/ImageDownloadService.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using RealityScraper.Application.Interfaces.Scraping;
 using RealityScraper.Domain.Entities.Realty;
+using RealityScraper.Infrastructure.Configuration;
 
 namespace RealityScraper.Infrastructure.Utilities;
 
@@ -10,15 +12,22 @@ public class ImageDownloadService : IImageDownloadService
 	private const long MaxImageSizeBytes = 10 * 1024 * 1024;
 	private static readonly TimeSpan DownloadTimeout = TimeSpan.FromSeconds(30);
 
+	// HttpClient sám žádný User-Agent neposílá a část CDN takový požadavek odmítne (typicky 403).
+	// Použije se stejná identita, jakou při scrapu vidí portál - obrázky se stahují z týchž serverů,
+	// takže rozejít ta dvě nastavení by znamenalo tichý výpadek stahování.
+	private const string FallbackUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";
+
 	private readonly IHttpClientFactory httpClientFactory;
 	private readonly ListingImagePathResolver pathResolver;
 	private readonly IUrlSafetyValidator urlSafetyValidator;
+	private readonly string userAgent;
 	private readonly ILogger<ImageDownloadService> logger;
 
 	public ImageDownloadService(
 		IHttpClientFactory httpClientFactory,
 		ListingImagePathResolver pathResolver,
 		IUrlSafetyValidator urlSafetyValidator,
+		IOptions<SeleniumOptions> seleniumOptions,
 		ILogger<ImageDownloadService> logger
 		)
 	{
@@ -26,6 +35,9 @@ public class ImageDownloadService : IImageDownloadService
 		this.pathResolver = pathResolver;
 		this.urlSafetyValidator = urlSafetyValidator;
 		this.logger = logger;
+
+		var configuredUserAgent = seleniumOptions.Value.UserAgent;
+		userAgent = string.IsNullOrWhiteSpace(configuredUserAgent) ? FallbackUserAgent : configuredUserAgent;
 	}
 
 	public async Task DownloadImageAsync(Listing listing, CancellationToken cancellationToken)
@@ -52,6 +64,9 @@ public class ImageDownloadService : IImageDownloadService
 		using var httpClient = httpClientFactory.CreateClient();
 		httpClient.Timeout = DownloadTimeout;
 		httpClient.MaxResponseContentBufferSize = MaxImageSizeBytes;
+
+		// TryAddWithoutValidation, aby překlep v konfiguraci neshodil stahování výjimkou.
+		httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgent);
 		byte[] imageBytes;
 
 		using (var response = await httpClient.GetAsync(imageUri, cancellationToken))

--- a/Web.Api/Components/App.razor
+++ b/Web.Api/Components/App.razor
@@ -17,6 +17,7 @@
 
 	<body>
 		<Routes @rendermode="PageRenderMode" />
+		<script src="@Assets["app.js"]"></script>
 		<script src="@Assets["_framework/blazor.web.js"]"></script>
 		@((MarkupString)@HxSetup.RenderBootstrapJavaScriptReference())
 	</body>

--- a/Web.Api/DependencyInjection.cs
+++ b/Web.Api/DependencyInjection.cs
@@ -23,7 +23,9 @@ public static class DependencyInjection
 				httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
 				_ => new FixedWindowRateLimiterOptions
 				{
-					PermitLimit = 100,
+					// Jedna stránka gridu Reality znamená ~16 requestů (data + náhled na řádek),
+					// při stovce za minutu by prolistování pár stránek shodilo i datový request.
+					PermitLimit = 300,
 					Window = TimeSpan.FromMinutes(1),
 					QueueLimit = 0
 				}));

--- a/Web.Api/Endpoints/Listings/GetListingImageEndpoint.cs
+++ b/Web.Api/Endpoints/Listings/GetListingImageEndpoint.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Diagnostics;
+using RealityScraper.Application.Interfaces.Scraping;
+
+namespace RealityScraper.Web.Api.Endpoints.Listings;
+
+internal sealed class GetListingImageEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapGet("/api/listings/{id:guid}/image", async (
+			Guid id,
+			IListingImageReader listingImageReader,
+			HttpContext httpContext,
+			CancellationToken cancellationToken) =>
+		{
+			var imageBytes = await listingImageReader.TryReadImageAsync(id, cancellationToken);
+			if (imageBytes == null)
+			{
+				// 404 je pro grid signál, aby zkusil hotlink na portál - viz listingThumbnailFallback v app.js.
+				// Bez vypnutí status code pages by se místo prázdné odpovědi překreslila celá SPA
+				// (~11 kB HTML), a to u každého chybějícího náhledu na stránce.
+				httpContext.Features.Get<IStatusCodePagesFeature>()?.Enabled = false;
+				return Results.NotFound();
+			}
+
+			// Snímek se mění jen při výměně titulní fotky na portálu a scrape běží řádově jednou denně.
+			httpContext.Response.Headers.CacheControl = "private, max-age=3600";
+
+			return Results.File(imageBytes, "image/jpeg");
+		});
+	}
+}

--- a/Web.Api/wwwroot/app.js
+++ b/Web.Api/wwwroot/app.js
@@ -1,0 +1,15 @@
+// Náhled inzerátu: lokálně nakešovaný snímek -> hotlink na portál -> placeholder.
+// Blazorové @onerror na <img> nefunguje (událost "error" nebublá a Blazor používá
+// delegované listenery), proto obyčejný HTML atribut onerror.
+window.listingThumbnailFallback = function (img) {
+	const portalUrl = img.dataset.portalUrl;
+	if (portalUrl) {
+		// Portálovou URL zkoušíme jen jednou, jinak by se při mrtvém odkazu točilo dokola.
+		img.dataset.portalUrl = '';
+		img.src = portalUrl;
+		return;
+	}
+
+	img.onerror = null;
+	img.src = '/img/listing-placeholder.svg';
+};

--- a/Web.Api/wwwroot/img/listing-placeholder.svg
+++ b/Web.Api/wwwroot/img/listing-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="60" viewBox="0 0 80 60" role="img" aria-label="Bez náhledu">
+	<rect width="80" height="60" fill="#e9ecef" />
+	<path d="M40 20 L54 32 L54 44 L44 44 L44 36 L36 36 L36 44 L26 44 L26 32 Z" fill="none" stroke="#adb5bd" stroke-width="2.5" stroke-linejoin="round" />
+</svg>

--- a/Web.Client/Pages/Listings/ListingListPage.razor
+++ b/Web.Client/Pages/Listings/ListingListPage.razor
@@ -48,10 +48,11 @@
     <Columns>
         <HxGridColumn HeaderText="Náhled">
             <ItemTemplate Context="listing">
-                @if (!string.IsNullOrEmpty(listing.ImageUrl))
-                {
-                    <img src="@listing.ImageUrl" alt="@listing.Title" width="80" height="60" loading="lazy" style="object-fit: cover; border-radius: 4px;" />
-                }
+                @* Nejdřív náš nakešovaný snímek, teprve při 404 hotlink na portál a nakonec placeholder. *@
+                <img src="@($"/api/listings/{listing.Id}/image")"
+                     data-portal-url="@listing.ImageUrl"
+                     onerror="listingThumbnailFallback(this)"
+                     alt="@listing.Title" width="80" height="60" loading="lazy" style="object-fit: cover; border-radius: 4px;" />
             </ItemTemplate>
         </HxGridColumn>
         <HxGridColumn HeaderText="Název">

--- a/Web.Client/Pages/Listings/ListingListPage.razor.cs
+++ b/Web.Client/Pages/Listings/ListingListPage.razor.cs
@@ -128,6 +128,12 @@ public partial class ListingListPage(
 			}
 
 			messenger.AddInformation(BuildBackfillMessage(result));
+
+			if (result.DownloadedCount > 0)
+			{
+				// Náhledy v gridu se čtou z lokální cache, po dotažení je potřeba si je znovu vyžádat.
+				await RefreshGridAsync();
+			}
 		}
 		catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
 		{


### PR DESCRIPTION
## Shrnutí

Portál může během života inzerátu vyměnit úvodní fotku. Aplikace to nereflektovala: `Listing.ImageUrl` se zapsala jednou při založení a nikdy se neaktualizovala. Jakmile se snímek změnil, uložená URL umřela a projevilo se to dvakrát — v gridu Reality se místo náhledu vykreslil glyf rozbitého obrázku a tlačítko „Dotáhnout chybějící náhledy“ pro takový inzerát nikdy neuspělo, protože stahuje právě z té mrtvé uložené URL. Přesně tohle je „Známé omezení“ sepsané v #93.

Příčina je jedno místo: `ScrapingReportBuilder.ProcessListingAsync` u existujícího inzerátu beze změny ceny zahodí celou nascrapovanou položku (`// Existující bez změn - jen započítáme do celkového počtu`). Scraper přitom URL obrázku čte z výpisu při **každém** běhu — jen se pokaždé zahodila. Stejnou vadou „zapiš jednou, nikdy neaktualizuj“ trpěly i `Title`, `Location` a `Url`.

## Změny

**Obnova údajů při scrapu** (e46b68b)

- `ScrapingReport.SeenExternalIds` (`IReadOnlySet<string>`) nahrazeno `SeenListings` (`IReadOnlyDictionary<string, ScraperListingItem>`) — jeden zdroj pravdy místo dvou kolekcí, které by se mohly rozejít. `RemovedListingDetector` přechází na `ContainsKey` beze změny chování.
- Builder ukládá viděnou položku **indexerem, ne `Add()`** — stejné externí ID může přijít ze dvou portálů (`processedListings` hlídá duplicity jen v rámci jednoho portálu) a `Add()` by shodil celý běh. Existující test `ScrapingReportBuilder_ProcessScraperResults_SameExternalIdOnDifferentSitesIsNotDeduplicated` dokládá, že ten případ nastává.
- `ListingChangeProcessor` obnoví `ImageUrl`, `Title`, `Location` a `Url`. Prázdná hodnota (selhaný selektor) ani hodnota nad limit sloupce uloženou nepřepíše, texty se porovnávají trimnuté.
- **Ukládá se surová URL, stahuje se podle normalizované cesty.** Do DB musí jít přesně to, co dnes funguje (query může nést podepsaný token), ale soubor se přestahuje jen při změně identity obrázku = cesty bez hostitele a query. Přehození inzerátu mezi CDN uzly ani jiné parametry zmenšení tak nestahují celou tabulku každý běh. Churn je vidět v logu, nad 50 % se loguje warning.

**Náhled v gridu z lokální cache** (f3b1f36)

- Nový `GET /api/listings/{id:guid}/image` servíruje nakešovaný snímek přes existující `IListingImageReader`. Cesta je shardovaná podle `Guid`, path traversal nehrozí.
- U chybějícího souboru vrací **prázdné** 404 — bez vypnutí status code pages by se místo toho překreslila celá SPA (~11 kB HTML), a to u každého chybějícího náhledu na stránce.
- `<img>` v gridu jede kaskádu **lokální cache → portál → placeholder**. Blazorové `@onerror` na `<img>` nefunguje (událost `error` nebublá a Blazor používá delegované listenery), proto obyčejný HTML atribut a funkce v novém `app.js`.
- `PermitLimit` rate limiteru zvednut ze 100 na 300. Jedna stránka gridu je nově ~16 requestů (data + náhled na řádek), při stovce za minutu by prolistování pár stránek shodilo i datový request.

**User-Agent při stahování** (301f7c9)

- `HttpClient` sám žádný `User-Agent` neposílá a část CDN takový požadavek odmítne — `upload.wikimedia.org` na něj vrací 403. Hodnota se bere z `SeleniumSettings:UserAgent`: obrázky se stahují z týchž serverů, jejichž stránky scrapuje prohlížeč, takže dvě různé identity by byly past — kdyby portál vynutil novější UA, bumpne se config u Selenia a stahování obrázků by tiše dál padalo. Prázdná konfigurace sáhne pro konstantu ve třídě, `TryAddWithoutValidation` brání pádu na překlepu.

Žádná EF migrace (schéma se nemění) a žádná změna v DI kromě rate limiteru — endpoint se registruje automaticky přes `IEndpoint`.

## Ověření

Celá sada **244/244 zelená**. Přibylo 26 testů, z toho tři na dosud nepokrytém `ImageDownloadService` (fake `HttpMessageHandler` a stuby, Moq tenhle projekt nepoužívá). Klíčové regrese: obnova URL i doplnění prázdné hodnoty, nepřepsání dobré URL prázdnou, **změna jen CDN uzlu / parametrů zmenšení nesmí spustit stahování**, URL nad limit sloupce, cenově změněný inzerát s novou fotkou jen jednou v `listingsToDownload`, a nový inzerát nezařazený ke stažení dvakrát.

Naživo proti lokální DB ověřena kaskáda náhledu na třech inzerátech:

| stav | výsledek |
|---|---|
| mrtvá `ImageUrl`, nakešovaný soubor | snímek z `/api/listings/{id}/image` |
| mrtvá `ImageUrl`, bez souboru | placeholder |
| živá `ImageUrl`, bez souboru | hotlink na portál |

Backfill: `checked 3, downloaded 1, failed 1` (mrtvá URL), soubor reálně na disku a endpoint ho servíruje. Po opravě UA stejná Wikimedia URL, která předtím padala na 403, projde: `checked 1, downloaded 1, failed 0`. Testovací data i soubory vráceny do původního stavu.

**Scrapovací část je ověřena jen testy, ne naživo** — seed DB má prázdný `ScraperTaskTarget` a Selenium hub lokálně neběží. Zápis obnovených hodnot stojí na tom, že `GetByScraperTaskIdAsync` vrací trackované entity, což je stejný mechanismus, jakým už dnes funguje aktualizace ceny.

## Známé omezení

- **Vyřazené inzeráty (`RemovedAt != null`) se nespraví nikdy.** Scraper je už nevidí, takže jejich URL nemá odkud obnovit, a `GetActiveWithImageUrlAsync` je filtruje pryč. Rozšířit dotaz backfillu o vyřazené by nemělo smysl — jejich URL jsou přesně ty mrtvé. Nově v gridu aspoň dostanou placeholder místo rozbitého obrázku a naši kopii, pokud existuje.
- **Nic se nespraví zpětně.** Přínos je dopředný: inzerát, který přežije aspoň jeden běh po nasazení, má čerstvou URL i nakešovaný soubor dřív, než ho portál stáhne.
- **Backfill zůstává potřeba** jako retry pro přechodná selhání stahování (5xx, timeout, odpověď bez `Content-Type: image/*`). Scrape stahuje jen při změně obrázku, neopakuje dřívější neúspěch u nezměněné URL.
- Mimo rozsah, ale stojí za samostatný úklid: `BackfillListingImagesCommandHandler` polyká výjimky z `DownloadImageAsync` bez logu, takže se z produkce nedozvíš, *proč* `failedCount` roste. Právě tohle tady zakrylo 403 od Wikimedie a muselo se dohledávat mimo aplikaci.