### PR TITLE
Feat: dashboard na homepage se stavem úloh a přehledem nálezů

### DIFF
--- a/Application.Tests/Features/Dashboard/GetDashboardSummaryQueryHandlerTests.cs
+++ b/Application.Tests/Features/Dashboard/GetDashboardSummaryQueryHandlerTests.cs
@@ -1,0 +1,177 @@
+﻿using Moq;
+using RealityScraper.Application.Features.Dashboard.GetSummary;
+using RealityScraper.Application.Interfaces.Repositories.Configuration;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.Domain.Entities.Realty;
+using RealityScraper.Domain.Entities.Tasks;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Tests.Features.Dashboard;
+
+public class GetDashboardSummaryQueryHandlerTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+	private readonly Mock<IListingRepository> listingRepositoryMock = new();
+	private readonly Mock<IScraperTaskRepository> scraperTaskRepositoryMock = new();
+	private readonly Mock<IDateTimeProvider> dateTimeProviderMock = new();
+
+	public GetDashboardSummaryQueryHandlerTests()
+	{
+		dateTimeProviderMock.SetupGet(x => x.UtcNow).Returns(Now);
+		SetupRepositories(new ListingDashboardStats(0, 0, 0, 0), [], []);
+	}
+
+	private GetDashboardSummaryQueryHandler CreateSut()
+	{
+		return new GetDashboardSummaryQueryHandler(
+			listingRepositoryMock.Object,
+			scraperTaskRepositoryMock.Object,
+			dateTimeProviderMock.Object);
+	}
+
+	private void SetupRepositories(
+		ListingDashboardStats stats,
+		List<Listing> latestListings,
+		List<ListingPriceDrop> priceDrops,
+		List<ScraperTask>? tasks = null)
+	{
+		listingRepositoryMock
+			.Setup(x => x.GetDashboardStatsAsync(It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(stats);
+
+		listingRepositoryMock
+			.Setup(x => x.GetPagedAsync(It.IsAny<bool?>(), It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((latestListings, latestListings.Count));
+
+		listingRepositoryMock
+			.Setup(x => x.GetRecentPriceDropsAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(priceDrops);
+
+		scraperTaskRepositoryMock
+			.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(tasks ?? []);
+	}
+
+	private static Listing CreateListing(Guid? scraperTaskId = null, decimal? price = 5_000_000)
+	{
+		return new Listing
+		{
+			Id = Guid.NewGuid(),
+			ExternalId = "ext-1",
+			Title = "Prodej domu",
+			Location = "Brno",
+			Url = "https://example.com/1",
+			ImageUrl = string.Empty,
+			Price = price,
+			CreatedAt = Now,
+			LastSeenAt = Now,
+			PriceFrom = Now,
+			ScraperTaskId = scraperTaskId
+		};
+	}
+
+	[Fact]
+	public async Task Handle_UsesSevenDayWindowFromCurrentTime()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetDashboardSummaryQuery(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(7, result.Value.WindowDays);
+		listingRepositoryMock.Verify(x => x.GetDashboardStatsAsync(Now.AddDays(-7), It.IsAny<CancellationToken>()), Times.Once);
+		listingRepositoryMock.Verify(x => x.GetRecentPriceDropsAsync(Now.AddDays(-7), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_AsksOnlyForActiveListingsOnFirstPage()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(new GetDashboardSummaryQuery(), CancellationToken.None);
+
+		// Assert
+		listingRepositoryMock.Verify(x => x.GetPagedAsync(true, null, null, 0, 6, It.IsAny<CancellationToken>()), Times.Once);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsCountsFromRepository()
+	{
+		// Arrange
+		SetupRepositories(new ListingDashboardStats(1248, 37, 22, 14), [], []);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetDashboardSummaryQuery(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal(1248, result.Value.ActiveCount);
+		Assert.Equal(37, result.Value.NewCount);
+		Assert.Equal(22, result.Value.RemovedCount);
+		Assert.Equal(14, result.Value.PriceDropCount);
+	}
+
+	[Fact]
+	public async Task Handle_MapsScraperTaskNameOnLatestListingsAndPriceDrops()
+	{
+		// Arrange
+		var task = new ScraperTask("Můj task", "0 * * * *", true, Now, null)
+		{
+			Id = Guid.NewGuid()
+		};
+		var listingWithTask = CreateListing(task.Id);
+		var listingWithoutTask = CreateListing();
+		var drop = new ListingPriceDrop(CreateListing(task.Id, 2_950_000), 3_200_000);
+		SetupRepositories(new ListingDashboardStats(0, 0, 0, 1), [listingWithTask, listingWithoutTask], [drop], [task]);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetDashboardSummaryQuery(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Equal("Můj task", result.Value.LatestListings[0].ScraperTaskName);
+		Assert.Null(result.Value.LatestListings[1].ScraperTaskName);
+		Assert.Equal("Můj task", result.Value.RecentPriceDrops[0].Listing.ScraperTaskName);
+	}
+
+	[Fact]
+	public async Task Handle_MapsPreviousPriceOnPriceDrops()
+	{
+		// Arrange
+		var drop = new ListingPriceDrop(CreateListing(price: 2_950_000), 3_200_000);
+		SetupRepositories(new ListingDashboardStats(0, 0, 0, 1), [], [drop]);
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetDashboardSummaryQuery(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		var mapped = Assert.Single(result.Value.RecentPriceDrops);
+		Assert.Equal(3_200_000, mapped.PreviousPrice);
+		Assert.Equal(2_950_000, mapped.Listing.Price);
+	}
+
+	[Fact]
+	public async Task Handle_ReturnsEmptyListsWhenThereIsNoData()
+	{
+		// Arrange
+		var sut = CreateSut();
+
+		// Act
+		var result = await sut.Handle(new GetDashboardSummaryQuery(), CancellationToken.None);
+
+		// Assert
+		Assert.True(result.IsSuccess);
+		Assert.Empty(result.Value.LatestListings);
+		Assert.Empty(result.Value.RecentPriceDrops);
+	}
+}

--- a/Application/Features/Dashboard/DashboardSummaryDto.cs
+++ b/Application/Features/Dashboard/DashboardSummaryDto.cs
@@ -1,0 +1,23 @@
+﻿using RealityScraper.Application.Features.Listings;
+
+namespace RealityScraper.Application.Features.Dashboard;
+
+public class DashboardSummaryDto
+{
+	/// <summary>
+	/// Délka klouzavého okna ve dnech, ze kterého jsou počítané změnové ukazatele.
+	/// </summary>
+	public int WindowDays { get; set; }
+
+	public int ActiveCount { get; set; }
+
+	public int NewCount { get; set; }
+
+	public int RemovedCount { get; set; }
+
+	public int PriceDropCount { get; set; }
+
+	public List<ListingDto> LatestListings { get; set; } = [];
+
+	public List<PriceDropDto> RecentPriceDrops { get; set; } = [];
+}

--- a/Application/Features/Dashboard/GetSummary/GetDashboardSummaryQuery.cs
+++ b/Application/Features/Dashboard/GetSummary/GetDashboardSummaryQuery.cs
@@ -1,0 +1,5 @@
+﻿using RealityScraper.Application.Abstractions.Messaging;
+
+namespace RealityScraper.Application.Features.Dashboard.GetSummary;
+
+public record GetDashboardSummaryQuery : IQuery<DashboardSummaryDto>;

--- a/Application/Features/Dashboard/GetSummary/GetDashboardSummaryQueryHandler.cs
+++ b/Application/Features/Dashboard/GetSummary/GetDashboardSummaryQueryHandler.cs
@@ -1,0 +1,78 @@
+﻿using RealityScraper.Application.Abstractions.Messaging;
+using RealityScraper.Application.Features.Listings;
+using RealityScraper.Application.Interfaces.Repositories.Configuration;
+using RealityScraper.Application.Interfaces.Repositories.Realty;
+using RealityScraper.SharedKernel;
+
+namespace RealityScraper.Application.Features.Dashboard.GetSummary;
+
+internal sealed class GetDashboardSummaryQueryHandler : IQueryHandler<GetDashboardSummaryQuery, DashboardSummaryDto>
+{
+	/// <summary>Klouzavé okno změnových ukazatelů – posledních 168 hodin, ne kalendářní týden.</summary>
+	private const int WindowDays = 7;
+
+	private const int LatestListingsCount = 6;
+
+	private const int PriceDropsCount = 5;
+
+	private readonly IListingRepository listingRepository;
+	private readonly IScraperTaskRepository scraperTaskRepository;
+	private readonly IDateTimeProvider dateTimeProvider;
+
+	public GetDashboardSummaryQueryHandler(
+		IListingRepository listingRepository,
+		IScraperTaskRepository scraperTaskRepository,
+		IDateTimeProvider dateTimeProvider)
+	{
+		this.listingRepository = listingRepository;
+		this.scraperTaskRepository = scraperTaskRepository;
+		this.dateTimeProvider = dateTimeProvider;
+	}
+
+	public async Task<Result<DashboardSummaryDto>> Handle(GetDashboardSummaryQuery query, CancellationToken cancellationToken)
+	{
+		var since = dateTimeProvider.UtcNow.AddDays(-WindowDays);
+
+		var stats = await listingRepository.GetDashboardStatsAsync(since, cancellationToken);
+
+		// Nejnovější inzeráty umí stránkovací dotaz – řadí CreatedAt DESC, takže stačí první stránka.
+		var (latestListings, _) = await listingRepository.GetPagedAsync(
+			isActive: true,
+			scraperTaskId: null,
+			searchTerm: null,
+			skip: 0,
+			take: LatestListingsCount,
+			cancellationToken);
+
+		var priceDrops = await listingRepository.GetRecentPriceDropsAsync(since, PriceDropsCount, cancellationToken);
+
+		var scraperTasks = await scraperTaskRepository.GetAllAsync(cancellationToken);
+		var taskNamesById = scraperTasks.ToDictionary(t => t.Id, t => t.Name);
+
+		var result = new DashboardSummaryDto
+		{
+			WindowDays = WindowDays,
+			ActiveCount = stats.ActiveCount,
+			NewCount = stats.NewCount,
+			RemovedCount = stats.RemovedCount,
+			PriceDropCount = stats.PriceDropCount,
+			LatestListings = latestListings
+				.Select(l => ListingMapper.MapToDto(l, GetTaskName(taskNamesById, l.ScraperTaskId)))
+				.ToList(),
+			RecentPriceDrops = priceDrops
+				.Select(d => new PriceDropDto
+				{
+					Listing = ListingMapper.MapToDto(d.Listing, GetTaskName(taskNamesById, d.Listing.ScraperTaskId)),
+					PreviousPrice = d.PreviousPrice
+				})
+				.ToList()
+		};
+
+		return Result.Success(result);
+	}
+
+	private static string? GetTaskName(Dictionary<Guid, string> taskNamesById, Guid? scraperTaskId)
+	{
+		return scraperTaskId.HasValue && taskNamesById.TryGetValue(scraperTaskId.Value, out var name) ? name : null;
+	}
+}

--- a/Application/Features/Dashboard/PriceDropDto.cs
+++ b/Application/Features/Dashboard/PriceDropDto.cs
@@ -1,0 +1,13 @@
+﻿using RealityScraper.Application.Features.Listings;
+
+namespace RealityScraper.Application.Features.Dashboard;
+
+public class PriceDropDto
+{
+	public ListingDto Listing { get; set; } = null!;
+
+	/// <summary>
+	/// Cena, ze které se zlevnilo. Aktuální cena je na <see cref="Listing"/>.
+	/// </summary>
+	public decimal PreviousPrice { get; set; }
+}

--- a/Application/Features/Listings/ListingDto.cs
+++ b/Application/Features/Listings/ListingDto.cs
@@ -1,4 +1,4 @@
-namespace RealityScraper.Application.Features.Listings;
+﻿namespace RealityScraper.Application.Features.Listings;
 
 public class ListingDto
 {
@@ -17,6 +17,9 @@ public class ListingDto
 	public DateTimeOffset CreatedAt { get; set; }
 
 	public DateTimeOffset LastSeenAt { get; set; }
+
+	/// <summary>Od kdy platí aktuální cena – u nezlevněného inzerátu je shodné s CreatedAt.</summary>
+	public DateTimeOffset PriceFrom { get; set; }
 
 	public DateTimeOffset? RemovedAt { get; set; }
 

--- a/Application/Features/Listings/ListingMapper.cs
+++ b/Application/Features/Listings/ListingMapper.cs
@@ -1,4 +1,4 @@
-using RealityScraper.Domain.Entities.Realty;
+﻿using RealityScraper.Domain.Entities.Realty;
 
 namespace RealityScraper.Application.Features.Listings;
 
@@ -16,6 +16,7 @@ internal static class ListingMapper
 			ImageUrl = entity.ImageUrl,
 			CreatedAt = entity.CreatedAt,
 			LastSeenAt = entity.LastSeenAt,
+			PriceFrom = entity.PriceFrom,
 			RemovedAt = entity.RemovedAt,
 			ScraperTaskId = entity.ScraperTaskId,
 			ScraperTaskName = scraperTaskName

--- a/Application/Interfaces/Repositories/Realty/IListingRepository.cs
+++ b/Application/Interfaces/Repositories/Realty/IListingRepository.cs
@@ -20,4 +20,14 @@ public interface IListingRepository
 	Task<(List<Listing> Items, int TotalCount)> GetPagedAsync(bool? isActive, Guid? scraperTaskId, string? searchTerm, int skip, int take, CancellationToken cancellationToken);
 
 	Task<Listing?> GetWithPriceHistoryAsync(Guid id, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Souhrnná čísla pro dashboard v klouzavém okně od <paramref name="since"/> do teď.
+	/// </summary>
+	Task<ListingDashboardStats> GetDashboardStatsAsync(DateTimeOffset since, CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Živé inzeráty, kterým od <paramref name="since"/> klesla cena, od nejčerstvějšího zlevnění.
+	/// </summary>
+	Task<List<ListingPriceDrop>> GetRecentPriceDropsAsync(DateTimeOffset since, int take, CancellationToken cancellationToken);
 }

--- a/Application/Interfaces/Repositories/Realty/ListingDashboardStats.cs
+++ b/Application/Interfaces/Repositories/Realty/ListingDashboardStats.cs
@@ -1,0 +1,12 @@
+﻿namespace RealityScraper.Application.Interfaces.Repositories.Realty;
+
+/// <summary>
+/// Souhrnná čísla inzerátů pro dashboard. <paramref name="NewCount"/> a <paramref name="RemovedCount"/>
+/// se počítají v klouzavém okně předaném do <see cref="IListingRepository.GetDashboardStatsAsync"/>.
+/// </summary>
+/// <param name="ActiveCount">Aktuálně živé inzeráty napříč všemi úlohami.</param>
+/// <param name="NewCount">Inzeráty poprvé zachycené v okně, bez ohledu na to, jestli mezitím zmizely.</param>
+/// <param name="RemovedCount">Inzeráty, které jsou vyřazené teď a byly vyřazené v okně. Znovuobjevený
+/// inzerát se nezapočítá – <c>RemovedListingDetector</c> mu <c>RemovedAt</c> vynuluje zpět.</param>
+/// <param name="PriceDropCount">Inzeráty, jejichž poslední cenová změna v okně byla zlevnění.</param>
+public record ListingDashboardStats(int ActiveCount, int NewCount, int RemovedCount, int PriceDropCount);

--- a/Application/Interfaces/Repositories/Realty/ListingPriceDrop.cs
+++ b/Application/Interfaces/Repositories/Realty/ListingPriceDrop.cs
@@ -1,0 +1,9 @@
+﻿using RealityScraper.Domain.Entities.Realty;
+
+namespace RealityScraper.Application.Interfaces.Repositories.Realty;
+
+/// <summary>
+/// Zlevněný inzerát i s cenou, ze které se zlevnilo. Aktuální cena je na <see cref="Listing.Price"/>,
+/// okamžik zlevnění na <see cref="Listing.PriceFrom"/>.
+/// </summary>
+public record ListingPriceDrop(Listing Listing, decimal PreviousPrice);

--- a/Infrastructure.Tests/Repositories/Realty/ListingRepositoryQueryTests.cs
+++ b/Infrastructure.Tests/Repositories/Realty/ListingRepositoryQueryTests.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.EntityFrameworkCore;
+using RealityScraper.Domain.Entities.Realty;
+using RealityScraper.Infrastructure.Contexts;
+using RealityScraper.Infrastructure.Repositories.Realty;
+
+namespace RealityScraper.Infrastructure.Tests.Repositories.Realty;
+
+// Ověřuje, že se dashboardový dotaz na zlevnění přeloží do SQL. ToQueryString() projde celým
+// překladem a nepotřebuje běžící databázi - stejně jako RealityDbContextModelTests.
+public class ListingRepositoryQueryTests
+{
+	private static readonly DateTimeOffset Since = new(2026, 7, 8, 12, 0, 0, TimeSpan.Zero);
+
+	private static RealityDbContext CreateContext()
+	{
+		var options = new DbContextOptionsBuilder<RealityDbContext>()
+			.UseNpgsql("Host=localhost;Database=reality_scraper;Username=test;Password=test")
+			.Options;
+
+		return new RealityDbContext(options);
+	}
+
+	private static string GetPriceDropsSql()
+	{
+		using var context = CreateContext();
+
+		return ListingRepository
+			.FilterPriceDropsSince(context.Set<Listing>().AsNoTracking(), Since)
+			.ToQueryString();
+	}
+
+	[Fact]
+	public void FilterPriceDropsSince_TranslatesToSql()
+	{
+		var sql = GetPriceDropsSql();
+
+		Assert.Contains("PriceHistory", sql, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void FilterPriceDropsSince_ComparesAgainstLastClosedPrice()
+	{
+		var sql = GetPriceDropsSql();
+
+		// Předchozí cena se bere jako jeden řádek historie s nejvyšším RecordedAt.
+		Assert.Contains("ORDER BY", sql, StringComparison.Ordinal);
+		Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void FilterPriceDropsSince_CountTranslatesToSql()
+	{
+		using var context = CreateContext();
+
+		// Stejný predikát se používá i pro počet zlevnění na dlaždici.
+		var sql = ListingRepository
+			.FilterPriceDropsSince(context.Set<Listing>().AsNoTracking(), Since)
+			.Select(x => x.Id)
+			.ToQueryString();
+
+		Assert.Contains("PriceHistory", sql, StringComparison.Ordinal);
+	}
+}

--- a/Infrastructure/Repositories/Realty/ListingRepository.cs
+++ b/Infrastructure/Repositories/Realty/ListingRepository.cs
@@ -84,6 +84,78 @@ internal class ListingRepository : Repository<Listing>, IListingRepository
 			.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
 	}
 
+	public async Task<ListingDashboardStats> GetDashboardStatsAsync(DateTimeOffset since, CancellationToken cancellationToken)
+	{
+		var listings = dbContext
+			.Set<Listing>()
+			.AsNoTracking();
+
+		// Čtyři samostatné COUNTy místo jednoho GroupBy: EF Core nepřeloží Count s predikátem
+		// uvnitř agregace a počet zlevnění navíc potřebuje korelovaný poddotaz. Tabulka má řádově
+		// tisíce řádků, čtyři roundtripy jsou levnější než riziko nepřeložitelného dotazu.
+		var activeCount = await listings.CountAsync(x => x.RemovedAt == null, cancellationToken);
+
+		// Bez ohledu na RemovedAt – inzerát byl v okně nový, i když už mezitím zmizel.
+		var newCount = await listings.CountAsync(x => x.CreatedAt >= since, cancellationToken);
+
+		// Znovuobjevený inzerát má RemovedAt zpátky na null (RemovedListingDetector), takže tohle
+		// je "aktuálně vyřazené, vyřazené v okně", ne "počet vyřazení v okně".
+		var removedCount = await listings.CountAsync(x => x.RemovedAt != null && x.RemovedAt >= since, cancellationToken);
+
+		var priceDropCount = await FilterPriceDropsSince(listings, since).CountAsync(cancellationToken);
+
+		return new ListingDashboardStats(activeCount, newCount, removedCount, priceDropCount);
+	}
+
+	public async Task<List<ListingPriceDrop>> GetRecentPriceDropsAsync(DateTimeOffset since, int take, CancellationToken cancellationToken)
+	{
+		// Historie se dotahuje přes Include, protože jde o pár řádků – druhý korelovaný poddotaz
+		// na předchozí cenu by byl dražší než načíst ji k vybraným inzerátům.
+		var listings = await FilterPriceDropsSince(dbContext.Set<Listing>().AsNoTracking(), since)
+			.OrderByDescending(x => x.PriceFrom)
+			.ThenBy(x => x.Id)
+			.Take(take)
+			.Include(x => x.PriceHistories)
+			.ToListAsync(cancellationToken);
+
+		return listings
+			.Select(x => new ListingPriceDrop(x, GetPreviousPrice(x)))
+			.ToList();
+	}
+
+	/// <summary>
+	/// Inzeráty, u kterých byla poslední cenová změna od <paramref name="since"/> zlevnění.
+	/// PriceFrom je okamžik poslední změny ceny a předchozí cena je v PriceHistory s nejvyšším
+	/// RecordedAt – ListingChangeProcessor tam při změně ukládá starou cenu se starým PriceFrom.
+	/// Prázdná historie i neznámá cena vypadnou samy, v SQL je NULL &gt; x vždy NULL.
+	/// Stejný predikát se používá i pro počet zlevnění, aby se číslo a seznam nemohly rozejít.
+	/// </summary>
+	internal static IQueryable<Listing> FilterPriceDropsSince(IQueryable<Listing> source, DateTimeOffset since)
+	{
+		return source.Where(x => x.RemovedAt == null
+			&& x.Price != null
+			&& x.PriceFrom >= since
+			&& x.PriceHistories
+				.OrderByDescending(h => h.RecordedAt)
+				.ThenByDescending(h => h.Id)
+				.Select(h => h.Price)
+				.FirstOrDefault() > x.Price);
+	}
+
+	/// <summary>
+	/// Poslední uzavřená cena inzerátu. Volá se až nad materializovaným výsledkem, který prošel
+	/// <see cref="FilterPriceDropsSince"/> – tam už je zaručeno, že nějaká známá cena existuje.
+	/// </summary>
+	private static decimal GetPreviousPrice(Listing listing)
+	{
+		return listing.PriceHistories
+			.Where(h => h.Price != null)
+			.OrderByDescending(h => h.RecordedAt)
+			.ThenByDescending(h => h.Id)
+			.Select(h => h.Price!.Value)
+			.First();
+	}
+
 	private static string EscapeLikePattern(string value)
 	{
 		return value

--- a/Web.Api/Endpoints/Dashboard/GetDashboardSummaryEndpoint.cs
+++ b/Web.Api/Endpoints/Dashboard/GetDashboardSummaryEndpoint.cs
@@ -1,0 +1,24 @@
+﻿using RealityScraper.Application.Abstractions.Messaging;
+using RealityScraper.Application.Features.Dashboard;
+using RealityScraper.Application.Features.Dashboard.GetSummary;
+using RealityScraper.Web.Api.Infrastructure;
+using RealityScraper.Web.Api.Mappers.Dashboard;
+
+namespace RealityScraper.Web.Api.Endpoints.Dashboard;
+
+internal sealed class GetDashboardSummaryEndpoint : IEndpoint
+{
+	public void MapEndpoint(IEndpointRouteBuilder app)
+	{
+		app.MapGet("/api/dashboard", async (
+			IQueryHandler<GetDashboardSummaryQuery, DashboardSummaryDto> queryHandler,
+			CancellationToken cancellationToken) =>
+		{
+			var result = await queryHandler.Handle(new GetDashboardSummaryQuery(), cancellationToken);
+
+			return result.IsSuccess
+				? Results.Ok(DashboardDtoMapper.MapToResult(result.Value))
+				: CustomResults.Problem(result);
+		});
+	}
+}

--- a/Web.Api/Mappers/Dashboard/DashboardDtoMapper.cs
+++ b/Web.Api/Mappers/Dashboard/DashboardDtoMapper.cs
@@ -1,0 +1,31 @@
+﻿using RealityScraper.Application.Features.Dashboard;
+using RealityScraper.Web.Api.Mappers.Listings;
+using RealityScraper.Web.Shared.Models.Dashboard;
+
+namespace RealityScraper.Web.Api.Mappers.Dashboard;
+
+public static class DashboardDtoMapper
+{
+	public static DashboardSummaryResult MapToResult(DashboardSummaryDto dto)
+	{
+		return new DashboardSummaryResult
+		{
+			WindowDays = dto.WindowDays,
+			ActiveCount = dto.ActiveCount,
+			NewCount = dto.NewCount,
+			RemovedCount = dto.RemovedCount,
+			PriceDropCount = dto.PriceDropCount,
+			LatestListings = dto.LatestListings.Select(ListingDtoMapper.MapToResult).ToList(),
+			RecentPriceDrops = dto.RecentPriceDrops.Select(MapToResult).ToList()
+		};
+	}
+
+	public static PriceDropResult MapToResult(PriceDropDto dto)
+	{
+		return new PriceDropResult
+		{
+			Listing = ListingDtoMapper.MapToResult(dto.Listing),
+			PreviousPrice = dto.PreviousPrice
+		};
+	}
+}

--- a/Web.Api/Mappers/Listings/ListingDtoMapper.cs
+++ b/Web.Api/Mappers/Listings/ListingDtoMapper.cs
@@ -1,4 +1,4 @@
-using RealityScraper.Application.Features.Listings;
+﻿using RealityScraper.Application.Features.Listings;
 using RealityScraper.Web.Shared.Models.Listings;
 
 namespace RealityScraper.Web.Api.Mappers.Listings;
@@ -26,6 +26,7 @@ public static class ListingDtoMapper
 			ImageUrl = dto.ImageUrl,
 			CreatedAt = dto.CreatedAt,
 			LastSeenAt = dto.LastSeenAt,
+			PriceFrom = dto.PriceFrom,
 			RemovedAt = dto.RemovedAt,
 			ScraperTaskId = dto.ScraperTaskId,
 			ScraperTaskName = dto.ScraperTaskName

--- a/Web.Client/Layout/NavMenu.razor
+++ b/Web.Client/Layout/NavMenu.razor
@@ -5,7 +5,7 @@
 		</HeaderTemplate>
 
 		<ItemsTemplate>
-			<HxSidebarItem Text="Home" Icon="BootstrapIcon.HouseDoorFill" Href="" Match="NavLinkMatch.All" TooltipText="Home" />
+			<HxSidebarItem Text="Přehled" Icon="BootstrapIcon.HouseDoorFill" Href="" Match="NavLinkMatch.All" TooltipText="Přehled" />
 			<HxSidebarItem Text="Scraper Tasks" Icon="BootstrapIcon.Search" Href="scraper-tasks" TooltipText="Scraper Tasks" />
 			<HxSidebarItem Text="Reporty" Icon="BootstrapIcon.Envelope" Href="report-tasks" TooltipText="Reporty" />
 			<HxSidebarItem Text="Reality" Icon="BootstrapIcon.Tags" Href="listings" TooltipText="Reality" />

--- a/Web.Client/Pages/Home.razor
+++ b/Web.Client/Pages/Home.razor
@@ -1,3 +1,214 @@
 ﻿@page "/"
+<PageTitle>Přehled</PageTitle>
 
-<h3>Homepage</h3>
+<h1 class="h3">Přehled</h1>
+
+@if (failedTaskNames.Count > 0)
+{
+    <HxAlert Color="ThemeColor.Warning" CssClass="d-flex align-items-center gap-2">
+        <HxIcon Icon="BootstrapIcon.ExclamationTriangleFill" />
+        <span>
+            Poslední běh selhal u těchto úloh: <strong>@string.Join(", ", failedTaskNames)</strong>.
+            Log najdete v jejich detailu.
+        </span>
+    </HxAlert>
+}
+
+@* KPI dlaždice *@
+<div class="row g-3 mb-4">
+    @foreach (var tile in BuildTiles())
+    {
+        <div class="col-6 col-xl-3" @key="tile.Label">
+            <div class="card h-100 kpi-card" title="@tile.Tooltip">
+                <div class="card-body">
+                    <div class="kpi-label">@tile.Label</div>
+                    @if (loadingSummary)
+                    {
+                        <div class="placeholder-glow"><span class="placeholder kpi-placeholder"></span></div>
+                    }
+                    else
+                    {
+                        <div class="kpi-value @tile.ValueCssClass">@tile.Value</div>
+                    }
+                    <div class="kpi-note">@tile.Note</div>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+@* Stav úloh *@
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Stav úloh</span>
+        <a href="scraper-tasks">spravovat →</a>
+    </div>
+    <div class="card-body p-0">
+        @if (loadingTasks)
+        {
+            <div class="p-3 placeholder-glow">
+                <span class="placeholder col-12 mb-2"></span>
+                <span class="placeholder col-12"></span>
+            </div>
+        }
+        else if (taskRows.Count == 0)
+        {
+            <div class="p-4 text-center">
+                <p class="text-muted mb-3">Zatím nemáte žádnou úlohu – bez ní se nic nescrapuje.</p>
+                <HxButton Text="Vytvořit scraper task" Icon="BootstrapIcon.PlusLg" Color="ThemeColor.Primary" OnClick="HandleCreateTaskClick" />
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Úloha</th>
+                            <th>Stav</th>
+                            <th>Poslední běh</th>
+                            <th>Následující běh</th>
+                            <th class="text-end">Akce</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var row in taskRows)
+                        {
+                            <tr @key="row.Id">
+                                <td>
+                                    <a href="@row.DetailUrl">@row.Name</a>
+                                    <div class="text-muted small">@row.KindLabel · @row.CronExpression</div>
+                                </td>
+                                <td class="text-nowrap">
+                                    @if (!row.Enabled)
+                                    {
+                                        <HxBadge Color="ThemeColor.Secondary">Vypnuto</HxBadge>
+                                    }
+                                    else if (row.LastRunSucceeded == true)
+                                    {
+                                        <HxBadge Color="ThemeColor.Success">OK</HxBadge>
+                                    }
+                                    else if (row.LastRunSucceeded == false)
+                                    {
+                                        <HxBadge Color="ThemeColor.Danger">Chyba</HxBadge>
+                                    }
+                                    else
+                                    {
+                                        @* Úloha, která ještě neběžela, není chyba - proto text, ne stavový badge. *@
+                                        <span class="text-muted small">zatím neběželo</span>
+                                    }
+                                </td>
+                                <td class="text-nowrap">@TimeZoneHelper.FormatLocal(row.LastRunAt)</td>
+                                <td class="text-nowrap">@(row.Enabled ? TimeZoneHelper.FormatLocal(row.NextRunAt) : "—")</td>
+                                <td class="text-end">
+                                    <HxButton Icon="BootstrapIcon.PlayFill" Color="ThemeColor.Success" Size="ButtonSize.Small" Outline="true"
+                                              Tooltip="Spustit teď" Enabled="runningTaskId != row.Id" OnClick="() => HandleRunNowClick(row)" />
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+<div class="row g-3">
+    @* Nejnovější inzeráty *@
+    <div class="col-12 col-xl-6">
+        <div class="card h-100">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span>Nejnovější inzeráty</span>
+                <a href="listings">zobrazit vše →</a>
+            </div>
+            <div class="card-body">
+                @if (loadingSummary)
+                {
+                    <div class="placeholder-glow">
+                        <span class="placeholder col-12 mb-3 listing-placeholder"></span>
+                        <span class="placeholder col-12 listing-placeholder"></span>
+                    </div>
+                }
+                else if (summary is null || summary.LatestListings.Count == 0)
+                {
+                    <p class="text-muted mb-0">Zatím nebyl nalezen žádný inzerát.</p>
+                }
+                else
+                {
+                    @foreach (var listing in summary.LatestListings)
+                    {
+                        <div class="listing-row" @key="listing.Id">
+                            @* Nejdřív náš nakešovaný snímek, teprve při 404 hotlink na portál a nakonec placeholder. *@
+                            <img class="listing-thumb"
+                                 src="@($"/api/listings/{listing.Id}/image")"
+                                 data-portal-url="@listing.ImageUrl"
+                                 onerror="listingThumbnailFallback(this)"
+                                 alt="@listing.Title" width="160" height="120" loading="lazy" />
+                            <div class="listing-body">
+                                <a class="listing-title" href="@listing.Url" target="_blank" rel="noopener">@listing.Title</a>
+                                <div class="text-muted small">@listing.Location</div>
+                                <div class="listing-price">@PriceFormatter.FormatPrice(listing.Price)</div>
+                                <div class="text-muted small">@listing.ScraperTaskName · nalezeno @TimeZoneHelper.FormatLocal(listing.CreatedAt)</div>
+                            </div>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    </div>
+
+    @* Poslední zlevnění *@
+    <div class="col-12 col-xl-6">
+        <div class="card h-100">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span>Poslední zlevnění</span>
+                <a href="listings">zobrazit vše →</a>
+            </div>
+            <div class="card-body">
+                @if (loadingSummary)
+                {
+                    <div class="placeholder-glow">
+                        <span class="placeholder col-12 mb-3 listing-placeholder"></span>
+                        <span class="placeholder col-12 listing-placeholder"></span>
+                    </div>
+                }
+                else if (summary is null || summary.RecentPriceDrops.Count == 0)
+                {
+                    <p class="text-muted mb-0">Za posledních @WindowDays dní nikdo nezlevnil.</p>
+                }
+                else
+                {
+                    @foreach (var drop in summary.RecentPriceDrops)
+                    {
+                        <div class="listing-row" @key="drop.Listing.Id">
+                            <img class="listing-thumb"
+                                 src="@($"/api/listings/{drop.Listing.Id}/image")"
+                                 data-portal-url="@drop.Listing.ImageUrl"
+                                 onerror="listingThumbnailFallback(this)"
+                                 alt="@drop.Listing.Title" width="160" height="120" loading="lazy" />
+                            <div class="listing-body">
+                                <a class="listing-title" href="@drop.Listing.Url" target="_blank" rel="noopener">@drop.Listing.Title</a>
+                                <div class="text-muted small">@drop.Listing.Location</div>
+                                <div class="listing-price">
+                                    <span class="listing-price-old">@PriceFormatter.FormatPrice(drop.PreviousPrice)</span>
+                                    <span class="text-nowrap">@PriceFormatter.FormatPrice(drop.Listing.Price)</span>
+                                </div>
+                                <div class="small text-nowrap">
+                                    <span class="text-success">
+                                        <HxIcon Icon="BootstrapIcon.CaretDownFill" />
+                                        @PriceFormatter.FormatSignedPrice(GetDifference(drop))
+                                        @if (GetDifferencePercent(drop) is { } percent)
+                                        {
+                                            <span>(@PriceFormatter.FormatSignedPercent(percent))</span>
+                                        }
+                                    </span>
+                                    <span class="text-muted">· @TimeZoneHelper.FormatLocal(drop.Listing.PriceFrom)</span>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    </div>
+</div>

--- a/Web.Client/Pages/Home.razor.cs
+++ b/Web.Client/Pages/Home.razor.cs
@@ -1,0 +1,187 @@
+﻿using System.Net.Http.Json;
+using System.Text.Json;
+using Havit.Blazor.Components.Web;
+using Havit.Blazor.Components.Web.Bootstrap;
+using Microsoft.AspNetCore.Components;
+using RealityScraper.Web.Shared;
+using RealityScraper.Web.Shared.Models.Dashboard;
+using RealityScraper.Web.Shared.Models.ReportTasks;
+using RealityScraper.Web.Shared.Models.ScraperTasks;
+
+namespace RealityScraper.Web.Client.Pages;
+
+public partial class Home(
+	HttpClient http,
+	IHxMessengerService messenger,
+	NavigationManager nav)
+{
+	/// <summary>Fallback pro popisky, než se načte skutečná délka okna z API.</summary>
+	private const int DefaultWindowDays = 7;
+
+	private DashboardSummaryResult? summary;
+	private List<TaskRow> taskRows = [];
+	private List<string> failedTaskNames = [];
+	private bool loadingSummary = true;
+	private bool loadingTasks = true;
+	private Guid? runningTaskId;
+
+	private int WindowDays => summary?.WindowDays ?? DefaultWindowDays;
+
+	protected override async Task OnInitializedAsync()
+	{
+		// Při SSR prerenderu nemá serverový HttpClient přihlašovací cookie, API by odpovědělo
+		// přesměrováním na login. Data se načtou až v interaktivním (WASM) renderu.
+		if (!RendererInfo.IsInteractive)
+		{
+			return;
+		}
+
+		// Každé volání má vlastní ošetření chyby - výpadek seznamu úloh nesmí vyprázdnit i dlaždice.
+		await Task.WhenAll(LoadSummaryAsync(), LoadTasksAsync());
+	}
+
+	private async Task LoadSummaryAsync()
+	{
+		loadingSummary = true;
+		try
+		{
+			summary = await http.GetFromJsonAsync<DashboardSummaryResult>("/api/dashboard");
+		}
+		catch (Exception ex) when (ex is HttpRequestException or JsonException or NotSupportedException or TaskCanceledException)
+		{
+			messenger.AddError("Nepodařilo se načíst souhrn inzerátů.");
+		}
+		finally
+		{
+			loadingSummary = false;
+		}
+	}
+
+	private async Task LoadTasksAsync()
+	{
+		loadingTasks = true;
+		try
+		{
+			var scraperTasksRequest = http.GetFromJsonAsync<List<ScraperTaskResult>>("/api/scraper-tasks");
+			var reportTasksRequest = http.GetFromJsonAsync<List<ReportTaskResult>>("/api/report-tasks");
+
+			var scraperTasks = await scraperTasksRequest ?? [];
+			var reportTasks = await reportTasksRequest ?? [];
+
+			taskRows =
+			[
+				.. scraperTasks.Select(t => new TaskRow(
+					t.Id, t.Name, "Scraper", t.CronExpression, t.Enabled, t.LastRunAt, t.NextRunAt, t.LastRunSucceeded,
+					$"/scraper-tasks/{t.Id}/edit", $"/api/scraper-tasks/{t.Id}/run-now")),
+				.. reportTasks.Select(t => new TaskRow(
+					t.Id, t.Name, "Report", t.CronExpression, t.Enabled, t.LastRunAt, t.NextRunAt, t.LastRunSucceeded,
+					$"/report-tasks/{t.Id}/edit", $"/api/report-tasks/{t.Id}/run-now"))
+			];
+
+			// Vypnutá úloha ani úloha, která ještě neběžela (LastRunSucceeded == null), není chyba.
+			failedTaskNames = taskRows
+				.Where(r => r.Enabled && r.LastRunSucceeded == false)
+				.Select(r => r.Name)
+				.ToList();
+		}
+		catch (Exception ex) when (ex is HttpRequestException or JsonException or NotSupportedException or TaskCanceledException)
+		{
+			messenger.AddError("Nepodařilo se načíst stav úloh.");
+		}
+		finally
+		{
+			loadingTasks = false;
+		}
+	}
+
+	private void HandleCreateTaskClick()
+	{
+		nav.NavigateTo("/scraper-tasks/create");
+	}
+
+	private async Task HandleRunNowClick(TaskRow row)
+	{
+		runningTaskId = row.Id;
+		try
+		{
+			using var response = await http.PostAsync(row.RunNowUrl, null);
+			if (response.IsSuccessStatusCode)
+			{
+				// Endpoint vrací 202 - úloha se spouští na pozadí, LastRunAt se hned nezmění.
+				messenger.AddInformation($"Úloha '{row.Name}' byla naplánována ke spuštění.");
+			}
+			else
+			{
+				messenger.AddError($"Nepodařilo se spustit úlohu '{row.Name}'.");
+			}
+		}
+		catch (Exception ex) when (ex is HttpRequestException or JsonException or NotSupportedException or TaskCanceledException)
+		{
+			messenger.AddError($"Nepodařilo se spustit úlohu '{row.Name}'.");
+		}
+		finally
+		{
+			runningTaskId = null;
+		}
+
+		await LoadTasksAsync();
+	}
+
+	private List<KpiTile> BuildTiles()
+	{
+		return
+		[
+			new KpiTile(
+				"Aktivní inzeráty",
+				summary is null ? "—" : PriceFormatter.FormatCount(summary.ActiveCount),
+				"celkem napříč úlohami",
+				"Inzeráty, které jsou na portálu stále k vidění.",
+				null),
+			new KpiTile(
+				"Nové",
+				summary is null ? "—" : PriceFormatter.FormatSignedCount(summary.NewCount),
+				$"za posledních {WindowDays} dní",
+				$"Inzeráty poprvé zachycené za posledních {WindowDays} dní, i když už mezitím zmizely.",
+				"text-primary"),
+			new KpiTile(
+				"Vyřazené",
+				summary is null ? "—" : PriceFormatter.FormatSignedCount(-summary.RemovedCount),
+				$"za posledních {WindowDays} dní",
+				$"Inzeráty vyřazené za posledních {WindowDays} dní, které se do teď nevrátily zpět.",
+				"text-muted"),
+			new KpiTile(
+				"Zlevněné",
+				summary is null ? "—" : PriceFormatter.FormatCount(summary.PriceDropCount),
+				$"za posledních {WindowDays} dní",
+				$"Živé inzeráty, jejichž poslední cenová změna za posledních {WindowDays} dní byla zlevnění.",
+				"text-success")
+		];
+	}
+
+	private static decimal GetDifference(PriceDropResult drop)
+	{
+		// Aktuální cena je u zlevnění vždy vyplněná, dotaz na zlevnění inzeráty bez ceny odfiltruje.
+		return (drop.Listing.Price ?? drop.PreviousPrice) - drop.PreviousPrice;
+	}
+
+	private static decimal? GetDifferencePercent(PriceDropResult drop)
+	{
+		return drop.PreviousPrice != 0
+			? GetDifference(drop) / drop.PreviousPrice * 100
+			: null;
+	}
+
+	private sealed record KpiTile(string Label, string Value, string Note, string Tooltip, string? ValueCssClass);
+
+	private sealed record TaskRow(
+		Guid Id,
+		string Name,
+		string KindLabel,
+		string CronExpression,
+		bool Enabled,
+		DateTimeOffset? LastRunAt,
+		DateTimeOffset? NextRunAt,
+		bool? LastRunSucceeded,
+		string DetailUrl,
+		string RunNowUrl);
+}

--- a/Web.Client/Pages/Home.razor.css
+++ b/Web.Client/Pages/Home.razor.css
@@ -1,0 +1,94 @@
+﻿/* KPI dlaždice */
+.kpi-card .card-body {
+	padding: var(--spacing-md) var(--spacing-lg);
+}
+
+.kpi-label {
+	font-size: 0.8125rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	color: var(--color-text-muted);
+}
+
+.kpi-value {
+	font-size: 2rem;
+	font-weight: 700;
+	line-height: 1.2;
+	color: var(--color-text);
+}
+
+.kpi-note {
+	font-size: 0.8125rem;
+	color: var(--color-text-light);
+}
+
+.kpi-placeholder {
+	width: 4rem;
+	height: 2rem;
+	border-radius: var(--radius-sm);
+}
+
+/* Seznam inzerátů */
+.listing-row {
+	display: flex;
+	gap: var(--spacing-md);
+	padding: var(--spacing-sm) 0;
+	border-bottom: 1px solid var(--color-border-light);
+}
+
+.listing-row:first-child {
+	padding-top: 0;
+}
+
+.listing-row:last-child {
+	padding-bottom: 0;
+	border-bottom: none;
+}
+
+.listing-thumb {
+	flex: 0 0 auto;
+	width: 160px;
+	height: 120px;
+	object-fit: cover;
+	border-radius: var(--radius-md);
+	background-color: var(--color-border-light);
+}
+
+.listing-body {
+	min-width: 0;
+}
+
+.listing-title {
+	display: block;
+	font-weight: 600;
+	line-height: 1.35;
+}
+
+.listing-price {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: var(--spacing-xs);
+	margin-top: var(--spacing-xs);
+	font-weight: 600;
+}
+
+.listing-price-old {
+	font-weight: 400;
+	color: var(--color-text-light);
+	text-decoration: line-through;
+}
+
+.listing-placeholder {
+	height: 120px;
+	border-radius: var(--radius-md);
+}
+
+/* Na úzkém displeji by náhled 160 px sebral text skoro celou šířku. */
+@media (max-width: 575.98px) {
+	.listing-thumb {
+		width: 96px;
+		height: 72px;
+	}
+}

--- a/Web.Client/Pages/Listings/ListingListPage.razor
+++ b/Web.Client/Pages/Listings/ListingListPage.razor
@@ -1,4 +1,4 @@
-@page "/listings"
+﻿@page "/listings"
 <PageTitle>Reality</PageTitle>
 
 <h3>Reality</h3>
@@ -63,7 +63,7 @@
         <HxGridColumn HeaderText="Lokalita" ItemTextSelector="l => l.Location" />
         <HxGridColumn HeaderText="Cena">
             <ItemTemplate Context="listing">
-                @FormatPrice(listing.Price)
+                @PriceFormatter.FormatPrice(listing.Price)
             </ItemTemplate>
         </HxGridColumn>
         <HxGridColumn HeaderText="Task" ItemTextSelector="l => l.ScraperTaskName" />
@@ -125,16 +125,16 @@
                                     <HxBadge Color="ThemeColor.Success" CssClass="ms-2">Aktuální</HxBadge>
                                 }
                             </td>
-                            <td class="text-end text-nowrap @(row.IsCurrent ? "fw-semibold" : null)">@FormatPrice(row.Price)</td>
+                            <td class="text-end text-nowrap @(row.IsCurrent ? "fw-semibold" : null)">@PriceFormatter.FormatPrice(row.Price)</td>
                             <td class="text-end">
                                 @if (row.Difference is { } difference && difference != 0)
                                 {
                                     <span class="text-nowrap @(difference > 0 ? "text-danger" : "text-success")">
                                         <HxIcon Icon="@(difference > 0 ? BootstrapIcon.CaretUpFill : BootstrapIcon.CaretDownFill)" />
-                                        @FormatSignedPrice(difference)
+                                        @PriceFormatter.FormatSignedPrice(difference)
                                         @if (row.DifferencePercent is { } percent)
                                         {
-                                            <span> (@FormatSignedPercent(percent))</span>
+                                            <span> (@PriceFormatter.FormatSignedPercent(percent))</span>
                                         }
                                     </span>
                                 }

--- a/Web.Client/Pages/Listings/ListingListPage.razor.cs
+++ b/Web.Client/Pages/Listings/ListingListPage.razor.cs
@@ -1,8 +1,8 @@
-using System.Globalization;
-using System.Net.Http.Json;
+﻿using System.Net.Http.Json;
 using System.Text.Json;
 using Havit.Blazor.Components.Web;
 using Havit.Blazor.Components.Web.Bootstrap;
+using RealityScraper.Web.Shared;
 using RealityScraper.Web.Shared.Models.Listings;
 using RealityScraper.Web.Shared.Models.Maintenance;
 using RealityScraper.Web.Shared.Models.ScraperTasks;
@@ -14,8 +14,6 @@ public partial class ListingListPage(
 	IHxMessengerService messenger)
 {
 	private const int DefaultPageSize = 15;
-
-	private static readonly CultureInfo czechCulture = CultureInfo.GetCultureInfo("cs-CZ");
 
 	private static readonly List<StateFilterOption> stateFilterOptions =
 	[
@@ -194,25 +192,6 @@ public partial class ListingListPage(
 		// nejnovější cena (aktuální) nahoře
 		rows.Reverse();
 		return rows;
-	}
-
-	private static string FormatPrice(decimal? price)
-	{
-		return price.HasValue
-			? string.Create(czechCulture, $"{price.Value:N0} Kč")
-			: "—";
-	}
-
-	private static string FormatSignedPrice(decimal difference)
-	{
-		var sign = difference > 0 ? "+" : "−";
-		return string.Create(czechCulture, $"{sign}{Math.Abs(difference):N0} Kč");
-	}
-
-	private static string FormatSignedPercent(decimal percent)
-	{
-		var sign = percent > 0 ? "+" : "−";
-		return string.Create(czechCulture, $"{sign}{Math.Abs(percent):N1} %");
 	}
 
 	private sealed record PriceHistoryRow(

--- a/Web.Client/_Imports.razor
+++ b/Web.Client/_Imports.razor
@@ -17,5 +17,6 @@
 @using RealityScraper.Web.Shared.Models.ScraperTaskRecipients
 @using RealityScraper.Web.Shared.Models.ScraperTaskTargets
 @using RealityScraper.Web.Shared.Models.ReportTasks
+@using RealityScraper.Web.Shared.Models.Dashboard
 @using RealityScraper.Web.Shared.Models.Listings
 @using Blazilla

--- a/Web.Shared/Models/Dashboard/DashboardSummaryResult.cs
+++ b/Web.Shared/Models/Dashboard/DashboardSummaryResult.cs
@@ -1,0 +1,20 @@
+﻿using RealityScraper.Web.Shared.Models.Listings;
+
+namespace RealityScraper.Web.Shared.Models.Dashboard;
+
+public class DashboardSummaryResult
+{
+	public int WindowDays { get; set; }
+
+	public int ActiveCount { get; set; }
+
+	public int NewCount { get; set; }
+
+	public int RemovedCount { get; set; }
+
+	public int PriceDropCount { get; set; }
+
+	public List<ListingResult> LatestListings { get; set; } = [];
+
+	public List<PriceDropResult> RecentPriceDrops { get; set; } = [];
+}

--- a/Web.Shared/Models/Dashboard/PriceDropResult.cs
+++ b/Web.Shared/Models/Dashboard/PriceDropResult.cs
@@ -1,0 +1,10 @@
+﻿using RealityScraper.Web.Shared.Models.Listings;
+
+namespace RealityScraper.Web.Shared.Models.Dashboard;
+
+public class PriceDropResult
+{
+	public ListingResult Listing { get; set; } = null!;
+
+	public decimal PreviousPrice { get; set; }
+}

--- a/Web.Shared/Models/Listings/ListingResult.cs
+++ b/Web.Shared/Models/Listings/ListingResult.cs
@@ -1,4 +1,4 @@
-namespace RealityScraper.Web.Shared.Models.Listings;
+﻿namespace RealityScraper.Web.Shared.Models.Listings;
 
 public class ListingResult
 {
@@ -17,6 +17,9 @@ public class ListingResult
 	public DateTimeOffset CreatedAt { get; set; }
 
 	public DateTimeOffset LastSeenAt { get; set; }
+
+	/// <summary>Od kdy platí aktuální cena – u nezlevněného inzerátu je shodné s CreatedAt.</summary>
+	public DateTimeOffset PriceFrom { get; set; }
 
 	public DateTimeOffset? RemovedAt { get; set; }
 

--- a/Web.Shared/PriceFormatter.cs
+++ b/Web.Shared/PriceFormatter.cs
@@ -1,0 +1,41 @@
+﻿using System.Globalization;
+
+namespace RealityScraper.Web.Shared;
+
+/// <summary>
+/// Jednotné formátování cen inzerátů pro UI – české oddělovače tisíců, bez desetinných míst.
+/// </summary>
+public static class PriceFormatter
+{
+	private static readonly CultureInfo CzechCulture = CultureInfo.GetCultureInfo("cs-CZ");
+
+	public static string FormatPrice(decimal? price)
+	{
+		return price.HasValue
+			? string.Create(CzechCulture, $"{price.Value:N0} Kč")
+			: "—";
+	}
+
+	public static string FormatSignedPrice(decimal difference)
+	{
+		var sign = difference > 0 ? "+" : "−";
+		return string.Create(CzechCulture, $"{sign}{Math.Abs(difference):N0} Kč");
+	}
+
+	public static string FormatSignedPercent(decimal percent)
+	{
+		var sign = percent > 0 ? "+" : "−";
+		return string.Create(CzechCulture, $"{sign}{Math.Abs(percent):N1} %");
+	}
+
+	public static string FormatCount(int count)
+	{
+		return count.ToString("N0", CzechCulture);
+	}
+
+	public static string FormatSignedCount(int count)
+	{
+		var sign = count > 0 ? "+" : "−";
+		return string.Create(CzechCulture, $"{sign}{Math.Abs(count):N0}");
+	}
+}


### PR DESCRIPTION
## Proč

Homepage byla prázdný placeholder (`@page "/"` + `<h3>Homepage</h3>`), přestože je to cíl odkazu v sidebaru a první, co uživatel po přihlášení vidí. Aplikace přitom drží data, která nikde souhrnně nejsou vidět — provozní stav úloh je rozstrkaný po dvou seznamech a informace o zlevnění jde zjistit jen proklikem na historii cen jednotlivého inzerátu.

Dashboard odpovídá na dvě otázky: **„běží mi to?"** a **„co je nového?"**

## Co je na stránce

- **4 KPI dlaždice** — aktivní inzeráty celkem, nové / vyřazené / zlevněné za posledních 7 dní (klouzavé okno, ne kalendářní týden; vysvětleno v tooltipu)
- **Stav úloh** — scraper i report tasky v jedné tabulce: badge OK / Chyba / Vypnuto, poslední a příští běh, tlačítko Spustit teď. Nahoře varování, když má zapnutá úloha poslední běh neúspěšný. Prázdný stav vede na založení tasku.
- **Nejnovější inzeráty** (6) a **Poslední zlevnění** (5) — náhledy 160×120, cena, u zlevnění stará cena, delta v Kč i %

## Backend

Nový `GET /api/dashboard` (`GetDashboardSummaryQueryHandler`) nad dvěma novými metodami `IListingRepository`. Souhrny se počítají v SQL, ne stahováním záznamů. Stav úloh se bere z existujících `/api/scraper-tasks` a `/api/report-tasks`, takže nový endpoint řeší jen inzeráty.

**Detekce zlevnění** staví na sémantice `ListingChangeProcessoru`: při změně ceny se do `PriceHistory` uloží *stará* cena se *starým* `PriceFrom`. Takže `Listing.PriceFrom` je okamžik poslední změny a předchozí cena leží v `PriceHistory` s nejvyšším `RecordedAt`. Predikát `FilterPriceDropsSince` je sdílený pro seznam i pro počet, aby se dlaždice a seznam nemohly rozejít.

Handler ani endpoint se nikde neregistrují ručně — Scrutor a `AddEndpoints` je najdou skenem. Autorizace a rate limit se dědí ze skupiny v `MapEndpoints()`. **Bez migrace** — model se nemění.

## Vedlejší změny

- `FormatPrice` / `FormatSignedPrice` / `FormatSignedPercent` vytaženy z `ListingListPage.razor.cs` do `Web.Shared/PriceFormatter.cs` místo duplikace na dashboardu; stránka Reality teď volá helper.
- `ListingDto` / `ListingResult` dostaly `PriceFrom` — bez toho nešlo zobrazit, *kdy* inzerát zlevnil.
- NavMenu: „Home" → „Přehled" kvůli konzistenci se zbytkem menu.

## Prerender

Data se načítají až v interaktivním renderu (`RendererInfo.IsInteractive`). Serverový `HttpClient "BlazorSSR"` nepřeposílá přihlašovací cookie, takže by `/api` při zapnuté autentizaci vrátilo přesměrování na login — a bez ní by se všechno načítalo dvakrát. Do catch filtrů přibyl `NotSupportedException`, který non-JSON odpověď jinak neodchytí.

## Ověření

- **253 testů zelených**, z toho 7 nových: `GetDashboardSummaryQueryHandlerTests` (okno 7 dní, mapování názvu tasku a předchozí ceny) a `ListingRepositoryQueryTests` (překlad dotazu na zlevnění přes `ToQueryString()`, bez běžící DB — v duchu `RealityDbContextModelTests`).
- **Predikát na zlevnění prohnán reálnými daty** v lokální DB: z 13 inzerátů s `PriceFrom` v okně prošel jen ten skutečně zlevněný. Zdražení, `NULL` cena, vyřazený inzerát i „beze změny" (ostrá nerovnost) správně vypadly a `priceDropCount` seděl s délkou seznamu.
- **V prohlížeči**: dashboard se vykreslil, konzole čistá, fallback náhledů projde až na placeholder, Spustit teď vrátí 202 a řádek se přepne na OK. Prerender skip potvrzen — `/api/scraper-tasks` se volá jednou, ne dvakrát.

## Co jsem neověřil

- **Mobilní šířku** — `resize_window` v testovacím Chrome viewport nezměnil. Responzivita stojí na standardním Bootstrap gridu (`col-6 col-xl-3`, `col-12 col-xl-6`, `table-responsive`) plus media query zmenšující náhled pod 576 px.
- **Stránku Reality po refaktoru formátování cen** — jen buildem, ne vizuálně. Jde o mechanickou záměnu za identickou implementaci.

## Poznámky k reviewu

- `RemovedCount` je „aktuálně vyřazené, vyřazené v okně", ne „počet vyřazení" — `RemovedListingDetector` umí `RemovedAt` vynulovat zpět. Okomentováno v kódu.
- Statistiky jsou 4 samostatné `CountAsync` místo jednoho `GroupBy` — EF Core nepřeloží `Count` s predikátem uvnitř agregace a počet zlevnění navíc potřebuje korelovaný poddotaz.
- `PriceFrom` ani `CreatedAt` nemají index, dashboardové globální filtry tedy jedou seq scanem. Při řádově tisících řádků irelevantní; index by znamenal migraci navíc.
