### PR TITLE
Fix: sjednocení počtu položek v obou panelech dashboardu

### DIFF
--- a/Application.Tests/Features/Dashboard/GetDashboardSummaryQueryHandlerTests.cs
+++ b/Application.Tests/Features/Dashboard/GetDashboardSummaryQueryHandlerTests.cs
@@ -101,6 +101,27 @@ public class GetDashboardSummaryQueryHandlerTests
 	}
 
 	[Fact]
+	public async Task Handle_AsksForSameNumberOfItemsInBothPanels()
+	{
+		// Arrange
+		var takes = new List<int>();
+		listingRepositoryMock
+			.Setup(x => x.GetPagedAsync(It.IsAny<bool?>(), It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<int>(), Capture.In(takes), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(([], 0));
+		listingRepositoryMock
+			.Setup(x => x.GetRecentPriceDropsAsync(It.IsAny<DateTimeOffset>(), Capture.In(takes), It.IsAny<CancellationToken>()))
+			.ReturnsAsync([]);
+		var sut = CreateSut();
+
+		// Act
+		await sut.Handle(new GetDashboardSummaryQuery(), CancellationToken.None);
+
+		// Assert - oba seznamy stojí na dashboardu vedle sebe, takže musí být stejně dlouhé.
+		Assert.Equal(2, takes.Count);
+		Assert.Equal(takes[0], takes[1]);
+	}
+
+	[Fact]
 	public async Task Handle_ReturnsCountsFromRepository()
 	{
 		// Arrange

--- a/Application/Features/Dashboard/GetSummary/GetDashboardSummaryQueryHandler.cs
+++ b/Application/Features/Dashboard/GetSummary/GetDashboardSummaryQueryHandler.cs
@@ -11,9 +11,12 @@ internal sealed class GetDashboardSummaryQueryHandler : IQueryHandler<GetDashboa
 	/// <summary>Klouzavé okno změnových ukazatelů – posledních 168 hodin, ne kalendářní týden.</summary>
 	private const int WindowDays = 7;
 
-	private const int LatestListingsCount = 6;
-
-	private const int PriceDropsCount = 5;
+	/// <summary>
+	/// Počet položek v obou seznamech na dashboardu. Nejnovější inzeráty a poslední zlevnění
+	/// stojí vedle sebe a mají stejně vysoké řádky, takže se drží na společném čísle - jinak
+	/// jeden sloupec bezdůvodně přesahuje druhý.
+	/// </summary>
+	private const int ListingsPerPanel = 6;
 
 	private readonly IListingRepository listingRepository;
 	private readonly IScraperTaskRepository scraperTaskRepository;
@@ -41,10 +44,10 @@ internal sealed class GetDashboardSummaryQueryHandler : IQueryHandler<GetDashboa
 			scraperTaskId: null,
 			searchTerm: null,
 			skip: 0,
-			take: LatestListingsCount,
+			take: ListingsPerPanel,
 			cancellationToken);
 
-		var priceDrops = await listingRepository.GetRecentPriceDropsAsync(since, PriceDropsCount, cancellationToken);
+		var priceDrops = await listingRepository.GetRecentPriceDropsAsync(since, ListingsPerPanel, cancellationToken);
 
 		var scraperTasks = await scraperTaskRepository.GetAllAsync(cancellationToken);
 		var taskNamesById = scraperTasks.ToDictionary(t => t.Id, t => t.Name);


### PR DESCRIPTION
Navazuje na #98.

## Proč

Panel „Nejnovější inzeráty" ukazoval šest položek, „Poslední zlevnění" pět. Obě čísla jsem v #98 zvolil bez odůvodnění. Panely přitom stojí vedle sebe a mají stejně vysoké řádky, takže se levý sloupec bezdůvodně protahoval pod pravý.

## Co se změnilo

`LatestListingsCount = 6` a `PriceDropsCount = 5` nahradil jeden konstant `ListingsPerPanel = 6` s komentářem, proč jsou svázané. Zlevnění se tím zobrazuje šest místo pěti; počet na dlaždici se nemění, ten se počítá zvlášť v SQL.

Nový test `Handle_AsksForSameNumberOfItemsInBothPanels` zachytí přes `Capture.In`, s jakým `take` se volají oba dotazy, a porovná je — kdyby se čísla zase rozešla, spadne. Ověřeno tím, že jsem konstantu dočasně rozpojil zpět na 5: test selhal, po vrácení prošel.
